### PR TITLE
feat: Add multiple return values support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,7 +244,7 @@ This document outlines the planned features and release schedule for Kronos.
   print call double with 5  # Prints: 10
   ```
 
-- **Multiple Return Values** - Tuple returns and destructuring
+- ✅ **Multiple Return Values** - Tuple returns and destructuring (completed)
 
   ```kronos
   function divide_with_remainder with a, b:

--- a/src/compiler/compiler.h
+++ b/src/compiler/compiler.h
@@ -58,6 +58,8 @@ typedef enum {
   OP_FORMAT_VALUE,  // Format value with spec (value, spec_idx -> formatted string)
   OP_MAKE_FUNCTION, // Create function value on stack (lambda)
   OP_CALL_VALUE,    // Call function value from stack
+  OP_TUPLE_NEW,     // Create new tuple (arg: element count)
+  OP_UNPACK,        // Unpack tuple/list into N values (arg: count)
   OP_HALT,          // End program
 } OpCode;
 

--- a/src/core/runtime.h
+++ b/src/core/runtime.h
@@ -19,6 +19,7 @@ typedef enum {
   VAL_CHANNEL,
   VAL_RANGE,
   VAL_MAP,
+  VAL_TUPLE, // Immutable fixed-size container for multiple return values
 } ValueType;
 
 // Reference-counted value
@@ -60,6 +61,10 @@ typedef struct KronosValue {
       size_t count;      // Number of active entries
       size_t capacity;   // Total capacity of hash table
     } map;
+    struct {
+      struct KronosValue **items; // Fixed-size array of values
+      size_t count;               // Number of items (immutable after creation)
+    } tuple;
   } as;
 } KronosValue;
 
@@ -85,6 +90,7 @@ KronosValue *value_new_list(size_t initial_capacity);
 KronosValue *value_new_channel(Channel *channel);
 KronosValue *value_new_range(double start, double end, double step);
 KronosValue *value_new_map(size_t initial_capacity);
+KronosValue *value_new_tuple(KronosValue **items, size_t count);
 
 // Reference counting
 // Both helpers treat NULL inputs as no-ops for convenience.

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -34,6 +34,8 @@ typedef enum {
   AST_TRY,          // Try/catch/finally exception handling
   AST_RAISE,        // Raise exception: raise ErrorType "message"
   AST_LAMBDA,       // Anonymous function expression
+  AST_TUPLE,        // Tuple expression: a, b, c
+  AST_UNPACK_ASSIGN, // Destructuring assignment: set x, y to expr
 } ASTNodeType;
 
 typedef struct ASTNode ASTNode;
@@ -175,8 +177,10 @@ struct ASTNode {
       size_t arg_count;
     } call;
 
+    // Return statement: return expr [, expr2, expr3, ...]
     struct {
-      ASTNode *value;
+      ASTNode **values;    // Array of return values
+      size_t value_count;  // Number of return values (1 for single return)
     } return_stmt;
 
     // Lambda: anonymous function expression
@@ -247,6 +251,20 @@ struct ASTNode {
       ASTNode *target; // Variable (map)
       ASTNode *key;    // Key expression
     } delete_stmt;
+
+    // Tuple expression: a, b, c (for multiple return values and swapping)
+    struct {
+      ASTNode **elements;
+      size_t element_count;
+    } tuple;
+
+    // Unpacking assignment: set x, y, z to expr
+    struct {
+      char **names;       // Array of variable names
+      size_t name_count;  // Number of names
+      ASTNode *value;     // Expression to unpack (should eval to tuple/list)
+      bool is_mutable;    // true for 'let', false for 'set'
+    } unpack_assign;
   } as;
 };
 

--- a/tests/integration/pass/multi_return_basic.kr
+++ b/tests/integration/pass/multi_return_basic.kr
@@ -1,0 +1,30 @@
+# Test: Basic multiple return values
+# Expected: Pass
+
+# Function that returns two values
+function divide_with_remainder with a, b:
+    let quotient to a divided by b
+    let quotient to call floor with quotient
+    set remainder to a mod b
+    return quotient, remainder
+
+# Call the function and unpack results
+set q, r to call divide_with_remainder with 10, 3
+print q
+print r
+
+# Another function returning multiple values
+function get_min_max with nums:
+    let min_val to nums at 0
+    let max_val to nums at 0
+    for n in nums:
+        if n is less than min_val:
+            let min_val to n
+        if n is greater than max_val:
+            let max_val to n
+    return min_val, max_val
+
+set numbers to list 5, 2, 8, 1, 9, 3
+set lo, hi to call get_min_max with numbers
+print lo
+print hi

--- a/tests/integration/pass/multi_return_swap.kr
+++ b/tests/integration/pass/multi_return_swap.kr
@@ -1,0 +1,31 @@
+# Test: Variable swapping with multiple assignment
+# Expected: Pass
+
+# Simple swap
+let x to 10
+let y to 20
+print x
+print y
+
+# Swap using tuple unpacking
+let x, y to y, x
+print x
+print y
+
+# Swap again to verify
+let x, y to y, x
+print x
+print y
+
+# Three-way rotation
+let a to 1
+let b to 2
+let c to 3
+print a
+print b
+print c
+
+let a, b, c to c, a, b
+print a
+print b
+print c

--- a/tests/integration/pass/multi_return_unpack.kr
+++ b/tests/integration/pass/multi_return_unpack.kr
@@ -1,0 +1,32 @@
+# Test: Unpacking assignment
+# Expected: Pass
+
+# Function returning a tuple
+function get_point:
+    return 10, 20
+
+# Unpack into variables
+set x, y to call get_point
+print x
+print y
+
+# Function returning three values
+function get_color:
+    return 255, 128, 64
+
+set r, g, b to call get_color
+print r
+print g
+print b
+
+# Nested function returning tuple
+function outer:
+    return 1, 2, 3
+
+function inner:
+    return call outer
+
+set p, q, s to call inner
+print p
+print q
+print s

--- a/tests/unit/test_parser.c
+++ b/tests/unit/test_parser.c
@@ -373,7 +373,7 @@ TEST(parse_return_statement) {
   ASSERT_PTR_NOT_NULL(ast);
   ASSERT_INT_EQ(ast->count, 1);
   ASSERT_INT_EQ(ast->statements[0]->type, AST_RETURN);
-  ASSERT_INT_EQ(ast->statements[0]->as.return_stmt.value->type, AST_NUMBER);
+  ASSERT_INT_EQ(ast->statements[0]->as.return_stmt.values[0]->type, AST_NUMBER);
 
   ast_free(ast);
   token_array_free(tokens);

--- a/website/content/docs/language/functions.mdx
+++ b/website/content/docs/language/functions.mdx
@@ -46,6 +46,66 @@ print result  # Prints: 8
 
 If no return statement is provided, the function returns `null`.
 
+## Multiple Return Values
+
+Functions can return multiple values using comma-separated expressions:
+
+```kronos
+function divide_with_remainder with a, b:
+    let quotient to a divided by b
+    let quotient to call floor with quotient
+    set remainder to a mod b
+    return quotient, remainder
+
+set q, r to call divide_with_remainder with 10, 3
+print q  # Prints: 3
+print r  # Prints: 1
+```
+
+### Unpacking Multiple Values
+
+Use comma-separated variable names to unpack multiple return values:
+
+```kronos
+function get_point:
+    return 10, 20
+
+set x, y to call get_point
+print x  # Prints: 10
+print y  # Prints: 20
+```
+
+### Variable Swapping
+
+Multiple assignment also enables elegant variable swapping:
+
+```kronos
+let x to 10
+let y to 20
+let x, y to y, x  # Swap values
+print x  # Prints: 20
+print y  # Prints: 10
+```
+
+### Practical Example
+
+```kronos
+function get_min_max with nums:
+    let min_val to nums at 0
+    let max_val to nums at 0
+    for n in nums:
+        if n is less than min_val:
+            let min_val to n
+        if n is greater than max_val:
+            let max_val to n
+    return min_val, max_val
+
+set numbers to list 5, 2, 8, 1, 9, 3
+set lo, hi to call get_min_max with numbers
+print lo  # Prints: 1
+print hi  # Prints: 9
+```
+
 ## Anonymous Functions (Lambdas)
 
 Anonymous functions (also called lambdas) are functions that can be assigned to variables and passed around as values. They are defined using the `function with` syntax without a function name.

--- a/website/content/docs/language/variables.mdx
+++ b/website/content/docs/language/variables.mdx
@@ -76,6 +76,58 @@ let counter to 100
 print counter  # 100
 ```
 
+## Unpacking Assignment
+
+Multiple variables can be assigned at once using unpacking syntax. This works with both `set` (immutable) and `let` (mutable).
+
+### Multiple Assignment
+
+```kronos
+set x, y to 10, 20
+print x  # 10
+print y  # 20
+
+let a, b, c to 1, 2, 3
+print a  # 1
+print b  # 2
+print c  # 3
+```
+
+### Variable Swapping
+
+Unpacking enables elegant variable swapping without a temporary variable:
+
+```kronos
+let x to 10
+let y to 20
+print x  # 10
+print y  # 20
+
+let x, y to y, x
+print x  # 20
+print y  # 10
+```
+
+### Unpacking Function Returns
+
+Functions can return multiple values, which can be unpacked into variables:
+
+```kronos
+function get_coordinates:
+    return 100, 200
+
+set x, y to call get_coordinates
+print x  # 100
+print y  # 200
+```
+
+<Callout type="warn">
+The number of variables must match the number of values being unpacked.
+```kronos
+set x, y to 1, 2, 3  # Error: count mismatch
+```
+</Callout>
+
 ---
 
 ## Type Annotations

--- a/website/content/docs/quick-reference.mdx
+++ b/website/content/docs/quick-reference.mdx
@@ -68,6 +68,15 @@ function greet with name:
     print f"Hello, {name}!"
 
 call greet with "Alice"
+
+# Multiple return values
+function divide with a, b:
+    return a divided by b, a mod b
+
+set q, r to call divide with 10, 3
+
+# Variable swapping
+let x, y to y, x
 ```
 
 ## Strings

--- a/website/content/docs/roadmap.mdx
+++ b/website/content/docs/roadmap.mdx
@@ -230,7 +230,7 @@ All features completed — you're looking at it!
 ### Advanced Language Features
 
 <Accordions>
-<Accordion title="String Interpolation Enhancements">
+<Accordion title="String Interpolation Enhancements ✓">
 Format specifiers for f-strings with precision, width, alignment, and type control.
 
 ```kronos
@@ -243,7 +243,7 @@ print f"|{x:0>5}|"            # |00042|
 ```
 </Accordion>
 
-<Accordion title="Anonymous Functions / Lambdas">
+<Accordion title="Anonymous Functions / Lambdas ✓">
 ```kronos
 set double to function with x: return x times 2
 
@@ -271,7 +271,7 @@ match value:
 ```
 </Accordion>
 
-<Accordion title="Multiple Return Values">
+<Accordion title="Multiple Return Values ✓">
 ```kronos
 function divide_with_remainder with a, b:
     return a divided by b, a mod b


### PR DESCRIPTION
## Summary

Add support for functions returning multiple values and unpacking assignments (`return a, b` and `set x, y to call func`).

## Changes

- Add `VAL_TUPLE` type to runtime for immutable fixed-size value containers
- Add `AST_TUPLE` and `AST_UNPACK_ASSIGN` parser nodes for tuple expressions and unpacking
- Add `OP_TUPLE_NEW` and `OP_UNPACK` opcodes for tuple creation and unpacking in VM
- Update LSP with symbol creation, reference finding, and diagnostics for tuples and unpacking
- Add integration tests for multiple return values, unpacking, and variable swapping

## Testing

- [x] All existing tests pass
- [x] New tests added (if applicable)
- [x] Examples updated (if applicable)
- [x] Memory leak checks pass (if applicable)

## Documentation

- [x] Examples updated (if applicable)
- [x] README/docs updated (if applicable)

## Breaking Changes

None
