### PR TITLE
Feat/list utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A high-performance programming language built in C with human-readable syntax, f
 - **Lists & Arrays**: List literals, indexing, slicing, and iteration
 - **Maps/Dictionaries**: Key-value storage with hash table implementation, map literals, and indexing
 - **Range Objects**: First-class range support with indexing, slicing, and iteration
-- **Enhanced Standard Library**: Math functions (sqrt, power, abs, round, floor, ceil, rand, min, max), type conversion (to_number, to_bool), and list utilities (reverse, sort)
+- **Enhanced Standard Library**: Math functions (sqrt, power, abs, round, floor, ceil, rand, min, max), type conversion (to_number, to_bool), and list utilities (reverse, sort, filter, map)
 - **Module System**: Import built-in modules (`import math`) and file-based modules (`import utils from "utils.kr"`). Use namespaced functions (`math.sqrt`, `utils.function`). String functions are global built-ins.
 - **Control Flow**: If/else-if/else, for/while loops, break/continue statements
 - **Functions**: First-class functions with parameters, return values, and local scoping

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -260,7 +260,7 @@ This document outlines the planned features and release schedule for Kronos.
   - ✅ Variadic functions: `function sum with ...numbers:`
   - ✅ Named arguments: `call create_user with name: "Alice", age: 30`
 
-- **List Utilities (Higher-Order)** - `filter()` and `map()` functions (requires lambdas)
+- ✅ **List Utilities (Higher-Order)** - `filter()` and `map()` functions (requires lambdas) (completed)
 
   ```kronos
   set evens to filter numbers with function with x: return x mod 2 is equal 0

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -3955,10 +3955,12 @@ static ASTNode *parse_call(Parser *p, int indent) {
     return NULL;
   }
 
-  Token *name = consume(p, TOK_NAME);
-  if (!name) {
+  Token *name = peek(p, 0);
+  if (!name || (name->type != TOK_NAME && name->type != TOK_MAP)) {
+    parser_set_error(p, "Expected function name after 'call'");
     return NULL;
   }
+  consume_any(p);
 
   // Parse arguments (including named arguments)
   size_t arg_capacity = 0;

--- a/src/lsp/lsp_completion.c
+++ b/src/lsp/lsp_completion.c
@@ -139,6 +139,8 @@ void handle_completion(const char *id, const char *body) {
       {"max", "Maximum of numbers"},
       {"reverse", "Reverse a list"},
       {"sort", "Sort a list"},
+      {"filter", "Filter a list with a callback function"},
+      {"map", "Transform a list with a callback function"},
       {"read_file", "Read entire file content as string"},
       {"write_file", "Write string content to file (path, content)"},
       {"read_lines", "Read file and return list of lines"},

--- a/src/lsp/lsp_diagnostics.c
+++ b/src/lsp/lsp_diagnostics.c
@@ -1663,8 +1663,10 @@ void check_undefined_variables(AST *ast, const char *text, Symbol *symbols,
         // node parameter not used in this branch - len accepts any type
         (void)node;
       } else if (strcmp(actual_func_name, "reverse") == 0 ||
-                 strcmp(actual_func_name, "sort") == 0) {
-        // These require list argument (not string)
+                 strcmp(actual_func_name, "sort") == 0 ||
+                 strcmp(actual_func_name, "filter") == 0 ||
+                 strcmp(actual_func_name, "map") == 0) {
+        // These require a list as the first argument (not string).
         if (node->as.call.arg_count > 0) {
           ASTNode *arg_node = node->as.call.args[0];
           (void)infer_type_with_ast(arg_node, symbols,

--- a/src/lsp/lsp_utils.c
+++ b/src/lsp/lsp_utils.c
@@ -1070,6 +1070,7 @@ int get_builtin_arg_count(const char *func_name) {
   if (strcmp(func_name, "add") == 0 || strcmp(func_name, "subtract") == 0 ||
       strcmp(func_name, "multiply") == 0 || strcmp(func_name, "divide") == 0 ||
       strcmp(func_name, "power") == 0 || strcmp(func_name, "split") == 0 ||
+      strcmp(func_name, "filter") == 0 || strcmp(func_name, "map") == 0 ||
       strcmp(func_name, "contains") == 0 ||
       strcmp(func_name, "starts_with") == 0 ||
       strcmp(func_name, "ends_with") == 0 ||

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -259,6 +259,7 @@ static void cleanup_call_frame_locals(CallFrame *frame) {
 int vm_execute(KronosVM *vm, Bytecode *bytecode);
 
 // Forward declarations for functions used in call_function_value
+static int push(KronosVM *vm, KronosValue *value);
 static KronosValue *pop(KronosVM *vm);
 static int vm_propagate_error(KronosVM *vm, KronosErrorCode fallback);
 
@@ -686,6 +687,136 @@ static int call_module_function(KronosVM *caller_vm, Module *mod,
   value_retain(return_val);
   value_release(return_val);
 
+  return 0;
+}
+
+/**
+ * @brief Execute a function value callback synchronously and return its result
+ *
+ * This helper is used by higher-order builtins like map/filter. It reuses
+ * call_function_value() to bind parameters/defaults, then executes the callback
+ * body in a nested vm_execute() call and restores the caller VM state.
+ *
+ * @param vm VM instance
+ * @param callback_name Name used in callback error messages
+ * @param callback Function value to invoke (must be VAL_FUNCTION)
+ * @param args Positional callback arguments
+ * @param arg_count Number of callback arguments
+ * @param out_result Receives callback return value on success
+ * @return 0 on success, negative error code on failure
+ */
+static int run_function_callback(KronosVM *vm, const char *callback_name,
+                                 KronosValue *callback, KronosValue **args,
+                                 uint8_t arg_count, KronosValue **out_result) {
+  if (!vm) {
+    return -(int)KRONOS_ERR_INVALID_ARGUMENT;
+  }
+  if (!callback || !out_result) {
+    return vm_error(vm, KRONOS_ERR_INVALID_ARGUMENT,
+                    "Invalid callback invocation state");
+  }
+
+  Bytecode *saved_bytecode = vm->bytecode;
+  uint8_t *saved_ip = vm->ip;
+  size_t saved_call_stack_size = vm->call_stack_size;
+  KronosValue **saved_stack_top = vm->stack_top;
+
+  for (uint8_t i = 0; i < arg_count; i++) {
+    int push_status = push(vm, args[i]);
+    if (push_status != 0) {
+      while (vm->stack_top > saved_stack_top) {
+        KronosValue *cleanup_val = pop(vm);
+        if (!cleanup_val) {
+          break;
+        }
+        value_release(cleanup_val);
+      }
+      return push_status;
+    }
+  }
+
+  int call_status =
+      call_function_value(vm, callback, callback_name ? callback_name : "callback",
+                          arg_count);
+  if (call_status != 0) {
+    while (vm->stack_top > saved_stack_top) {
+      KronosValue *cleanup_val = pop(vm);
+      if (!cleanup_val) {
+        break;
+      }
+      value_release(cleanup_val);
+    }
+    vm->bytecode = saved_bytecode;
+    vm->ip = saved_ip;
+    return call_status;
+  }
+
+  if (vm->call_stack_size <= saved_call_stack_size) {
+    vm->bytecode = saved_bytecode;
+    vm->ip = saved_ip;
+    return vm_error(vm, KRONOS_ERR_INTERNAL,
+                    "Callback call frame was not created");
+  }
+
+  // Tell OP_RETURN_VAL to return from nested vm_execute immediately.
+  CallFrame *callback_frame = &vm->call_stack[vm->call_stack_size - 1];
+  callback_frame->return_ip = NULL;
+  callback_frame->return_bytecode = NULL;
+
+  int exec_status = vm_execute(vm, vm->bytecode);
+  if (exec_status != 0) {
+    if (vm->call_stack_size > saved_call_stack_size) {
+      callback_frame = &vm->call_stack[vm->call_stack_size - 1];
+      cleanup_call_frame_locals(callback_frame);
+      if (callback_frame->owned_bytecode) {
+        free(callback_frame->owned_bytecode);
+        callback_frame->owned_bytecode = NULL;
+      }
+      vm->call_stack_size--;
+    }
+    vm->current_frame = saved_call_stack_size > 0
+                            ? &vm->call_stack[saved_call_stack_size - 1]
+                            : NULL;
+    vm->bytecode = saved_bytecode;
+    vm->ip = saved_ip;
+    return exec_status;
+  }
+
+  KronosValue *result = pop(vm);
+  if (!result) {
+    if (vm->call_stack_size > saved_call_stack_size) {
+      callback_frame = &vm->call_stack[vm->call_stack_size - 1];
+      cleanup_call_frame_locals(callback_frame);
+      if (callback_frame->owned_bytecode) {
+        free(callback_frame->owned_bytecode);
+        callback_frame->owned_bytecode = NULL;
+      }
+      vm->call_stack_size--;
+    }
+    vm->current_frame = saved_call_stack_size > 0
+                            ? &vm->call_stack[saved_call_stack_size - 1]
+                            : NULL;
+    vm->bytecode = saved_bytecode;
+    vm->ip = saved_ip;
+    return vm_propagate_error(vm, KRONOS_ERR_RUNTIME);
+  }
+
+  if (vm->call_stack_size > saved_call_stack_size) {
+    callback_frame = &vm->call_stack[vm->call_stack_size - 1];
+    cleanup_call_frame_locals(callback_frame);
+    if (callback_frame->owned_bytecode) {
+      free(callback_frame->owned_bytecode);
+      callback_frame->owned_bytecode = NULL;
+    }
+    vm->call_stack_size--;
+  }
+
+  vm->current_frame =
+      saved_call_stack_size > 0 ? &vm->call_stack[saved_call_stack_size - 1]
+                                : NULL;
+  vm->bytecode = saved_bytecode;
+  vm->ip = saved_ip;
+  *out_result = result;
   return 0;
 }
 
@@ -2147,6 +2278,8 @@ static int builtin_to_number(KronosVM *vm, uint8_t arg_count);
 static int builtin_to_bool(KronosVM *vm, uint8_t arg_count);
 static int builtin_reverse(KronosVM *vm, uint8_t arg_count);
 static int builtin_sort(KronosVM *vm, uint8_t arg_count);
+static int builtin_filter(KronosVM *vm, uint8_t arg_count);
+static int builtin_map(KronosVM *vm, uint8_t arg_count);
 static int builtin_write_file(KronosVM *vm, uint8_t arg_count);
 static int builtin_read_lines(KronosVM *vm, uint8_t arg_count);
 static int builtin_file_exists(KronosVM *vm, uint8_t arg_count);
@@ -4428,6 +4561,156 @@ static int builtin_sort(KronosVM *vm, uint8_t arg_count) {
   return 0;
 }
 
+static int builtin_filter(KronosVM *vm, uint8_t arg_count) {
+  if (arg_count != 2) {
+    return vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                     "Function 'filter' expects 2 arguments, got %d",
+                     arg_count);
+  }
+  KronosValue *callback_arg;
+  POP_OR_RETURN(vm, callback_arg);
+  KronosValue *list_arg;
+  POP_OR_RETURN_WITH_CLEANUP(vm, list_arg, value_release(callback_arg));
+
+  if (list_arg->type != VAL_LIST) {
+    int err = vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                        "Function 'filter' requires a list argument");
+    value_release(callback_arg);
+    value_release(list_arg);
+    return err;
+  }
+  if (callback_arg->type != VAL_FUNCTION) {
+    int err = vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                        "Function 'filter' requires a function argument");
+    value_release(callback_arg);
+    value_release(list_arg);
+    return err;
+  }
+
+  KronosValue *result = value_new_list(list_arg->as.list.count);
+  if (!result) {
+    value_release(callback_arg);
+    value_release(list_arg);
+    return vm_error(vm, KRONOS_ERR_INTERNAL, "Failed to create list");
+  }
+
+  for (size_t i = 0; i < list_arg->as.list.count; i++) {
+    KronosValue *callback_args[1] = {list_arg->as.list.items[i]};
+    KronosValue *callback_result = NULL;
+    int status = run_function_callback(vm, "filter callback", callback_arg,
+                                       callback_args, 1, &callback_result);
+    if (status != 0) {
+      value_release(result);
+      value_release(callback_arg);
+      value_release(list_arg);
+      return status;
+    }
+
+    bool keep_item = value_is_truthy(callback_result);
+    value_release(callback_result);
+    if (!keep_item) {
+      continue;
+    }
+
+    if (result->as.list.count >= result->as.list.capacity) {
+      size_t new_cap = result->as.list.capacity * 2;
+      KronosValue **new_items =
+          realloc(result->as.list.items, sizeof(KronosValue *) * new_cap);
+      if (!new_items) {
+        value_release(result);
+        value_release(callback_arg);
+        value_release(list_arg);
+        return vm_error(vm, KRONOS_ERR_INTERNAL, "Failed to grow list");
+      }
+      result->as.list.items = new_items;
+      result->as.list.capacity = new_cap;
+    }
+
+    value_retain(list_arg->as.list.items[i]);
+    result->as.list.items[result->as.list.count++] = list_arg->as.list.items[i];
+  }
+
+  PUSH_OR_RETURN_WITH_CLEANUP(vm, result, value_release(result);
+                              value_release(callback_arg);
+                              value_release(list_arg););
+  value_release(result);
+  value_release(callback_arg);
+  value_release(list_arg);
+  return 0;
+}
+
+static int builtin_map(KronosVM *vm, uint8_t arg_count) {
+  if (arg_count != 2) {
+    return vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                     "Function 'map' expects 2 arguments, got %d", arg_count);
+  }
+  KronosValue *callback_arg;
+  POP_OR_RETURN(vm, callback_arg);
+  KronosValue *list_arg;
+  POP_OR_RETURN_WITH_CLEANUP(vm, list_arg, value_release(callback_arg));
+
+  if (list_arg->type != VAL_LIST) {
+    int err = vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                        "Function 'map' requires a list argument");
+    value_release(callback_arg);
+    value_release(list_arg);
+    return err;
+  }
+  if (callback_arg->type != VAL_FUNCTION) {
+    int err = vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                        "Function 'map' requires a function argument");
+    value_release(callback_arg);
+    value_release(list_arg);
+    return err;
+  }
+
+  KronosValue *result = value_new_list(list_arg->as.list.count);
+  if (!result) {
+    value_release(callback_arg);
+    value_release(list_arg);
+    return vm_error(vm, KRONOS_ERR_INTERNAL, "Failed to create list");
+  }
+
+  for (size_t i = 0; i < list_arg->as.list.count; i++) {
+    KronosValue *callback_args[1] = {list_arg->as.list.items[i]};
+    KronosValue *mapped_value = NULL;
+    int status = run_function_callback(vm, "map callback", callback_arg,
+                                       callback_args, 1, &mapped_value);
+    if (status != 0) {
+      value_release(result);
+      value_release(callback_arg);
+      value_release(list_arg);
+      return status;
+    }
+
+    if (result->as.list.count >= result->as.list.capacity) {
+      size_t new_cap = result->as.list.capacity * 2;
+      KronosValue **new_items =
+          realloc(result->as.list.items, sizeof(KronosValue *) * new_cap);
+      if (!new_items) {
+        value_release(mapped_value);
+        value_release(result);
+        value_release(callback_arg);
+        value_release(list_arg);
+        return vm_error(vm, KRONOS_ERR_INTERNAL, "Failed to grow list");
+      }
+      result->as.list.items = new_items;
+      result->as.list.capacity = new_cap;
+    }
+
+    // mapped_value comes from stack pop(), transfer ownership to result list.
+    result->as.list.items[result->as.list.count++] = mapped_value;
+  }
+
+  PUSH_OR_RETURN_WITH_CLEANUP(vm, result, value_release(result);
+                              value_release(callback_arg);
+                              value_release(list_arg););
+  value_release(result);
+  value_release(callback_arg);
+  value_release(list_arg);
+  return 0;
+}
+
 static int builtin_write_file(KronosVM *vm, uint8_t arg_count) {
   if (arg_count != 2) {
     return vm_errorf(vm, KRONOS_ERR_RUNTIME,
@@ -5091,6 +5374,7 @@ static const BuiltinEntry builtin_table[] = {
     {"divide", builtin_divide},
     {"ends_with", builtin_ends_with},
     {"file_exists", builtin_file_exists},
+    {"filter", builtin_filter},
     {"findall", builtin_regex_findall},
     {"floor", builtin_floor},
     {"join", builtin_join},
@@ -5098,6 +5382,7 @@ static const BuiltinEntry builtin_table[] = {
     {"len", builtin_len},
     {"list_files", builtin_list_files},
     {"lowercase", builtin_lowercase},
+    {"map", builtin_map},
     {"match", builtin_regex_match},
     {"max", builtin_max},
     {"min", builtin_min},

--- a/tests/integration/fail/list_higher_order_arity_error.kr
+++ b/tests/integration/fail/list_higher_order_arity_error.kr
@@ -1,0 +1,5 @@
+# Test higher-order list utility callback arity validation
+
+set nums to list 1, 2, 3
+set bad_map to call map with nums, function with a, b: return a plus b
+# Expected: Runtime error - callback requires 2 arguments but map provides 1

--- a/tests/integration/fail/list_higher_order_callback_error.kr
+++ b/tests/integration/fail/list_higher_order_callback_error.kr
@@ -1,0 +1,5 @@
+# Test higher-order list utility callback errors
+
+set nums to list 1, 2, 3
+set bad_filter to call filter with nums, 42
+# Expected: Runtime error - filter requires a function argument

--- a/tests/integration/fail/list_higher_order_error.kr
+++ b/tests/integration/fail/list_higher_order_error.kr
@@ -1,0 +1,5 @@
+# Test higher-order list utility errors
+
+# map with non-list first argument
+set bad_map to call map with "hello", function with x: return x
+# Expected: Runtime error - map requires a list argument

--- a/tests/integration/pass/list_higher_order.kr
+++ b/tests/integration/pass/list_higher_order.kr
@@ -1,0 +1,25 @@
+# Test higher-order list utilities: filter and map
+
+set numbers to list 1, 2, 3, 4, 5
+
+# Filter even numbers
+set evens to call filter with numbers, function with x: return x mod 2 is equal 0
+print evens
+# Expected: [2, 4]
+
+# Map numbers to doubled values
+set doubled to call map with numbers, function with x: return x times 2
+print doubled
+# Expected: [2, 4, 6, 8, 10]
+
+# Filter using truthy callback result
+set mixed_truthy to list 0, 1, 2, 0, 3
+set truthy_only to call filter with mixed_truthy, function with x: x
+print truthy_only
+# Expected: [1, 2, 3]
+
+# Map strings to their lengths
+set words to list "a", "bb", "ccc"
+set lengths to call map with words, function with word: return call len with word
+print lengths
+# Expected: [1, 2, 3]

--- a/tests/lsp/test_lsp_features.c
+++ b/tests/lsp/test_lsp_features.c
@@ -4,6 +4,25 @@
 
 LSPTestContext *g_ctx = NULL; // Global for test setup/teardown
 
+static char *lsp_read_diagnostics_with_message(const char *message_substring,
+                                               int max_attempts) {
+  for (int i = 0; i < max_attempts; i++) {
+    char *msg = lsp_read_response(g_ctx, 500);
+    if (!msg) {
+      continue;
+    }
+    bool is_diagnostics =
+        lsp_response_contains(msg, "textDocument/publishDiagnostics");
+    bool has_message =
+        !message_substring || lsp_response_contains(msg, message_substring);
+    if (is_diagnostics && has_message) {
+      return msg;
+    }
+    free(msg);
+  }
+  return NULL;
+}
+
 // Test hover for file-based modules
 TEST(lsp_hover_file_module) {
   const char *code = "import math\n"
@@ -257,6 +276,49 @@ TEST(lsp_diagnostics_variadic_valid) {
   ASSERT_TRUE(true);
 }
 
+TEST(lsp_diagnostics_map_requires_list_argument) {
+  const char *code = "call map with \"hello\", function with x: return x\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000); // 100ms
+  char *diag = lsp_read_diagnostics_with_message(
+      "Function 'map' requires a list argument", 6);
+  ASSERT_PTR_NOT_NULL(diag);
+  ASSERT_TRUE(lsp_is_valid_json(diag));
+  ASSERT_TRUE(lsp_response_contains(diag, "Function 'map' requires a list argument"));
+  free(diag);
+}
+
+TEST(lsp_diagnostics_filter_requires_list_argument) {
+  const char *code = "call filter with \"hello\", function with x: return x\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000); // 100ms
+  char *diag = lsp_read_diagnostics_with_message(
+      "Function 'filter' requires a list argument", 6);
+  ASSERT_PTR_NOT_NULL(diag);
+  ASSERT_TRUE(lsp_is_valid_json(diag));
+  ASSERT_TRUE(lsp_response_contains(diag, "Function 'filter' requires a list argument"));
+  free(diag);
+}
+
+TEST(lsp_completion_includes_filter_and_map_utilities) {
+  const char *code = "set numbers to list 1, 2, 3\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  // Consume diagnostics notification triggered by didOpen first.
+  usleep(100000); // 100ms
+  char *diag = lsp_read_diagnostics_with_message(NULL, 4);
+  free(diag);
+
+  char *response = lsp_completion(g_ctx, 0, 5);
+  ASSERT_PTR_NOT_NULL(response);
+  ASSERT_TRUE(lsp_is_valid_json(response));
+  ASSERT_TRUE(lsp_response_contains(response, "Filter a list with a callback function"));
+  ASSERT_TRUE(lsp_response_contains(response, "Transform a list with a callback function"));
+  free(response);
+}
+
 // Setup and teardown
 void lsp_test_setup(void) {
   if (!g_ctx) {
@@ -273,4 +335,3 @@ void lsp_test_teardown(void) {
     g_ctx = NULL;
   }
 }
-

--- a/tests/lsp/test_lsp_framework.c
+++ b/tests/lsp/test_lsp_framework.c
@@ -1,6 +1,7 @@
 #include "test_lsp_framework.h"
 #include <sys/wait.h>
 #include <sys/types.h>
+#include <sys/select.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -161,6 +162,23 @@ bool lsp_send_request(LSPTestContext *ctx, const char *method, const char *param
 char *lsp_read_response(LSPTestContext *ctx, int timeout_ms) {
   if (!ctx || !ctx->lsp_stdout)
     return NULL;
+
+  int fd = fileno(ctx->lsp_stdout);
+  if (fd < 0)
+    return NULL;
+
+  fd_set read_fds;
+  FD_ZERO(&read_fds);
+  FD_SET(fd, &read_fds);
+
+  struct timeval timeout;
+  timeout.tv_sec = timeout_ms / 1000;
+  timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+  int ready = select(fd + 1, &read_fds, NULL, NULL, &timeout);
+  if (ready <= 0) {
+    return NULL;
+  }
 
   int length = read_content_length(ctx->lsp_stdout);
   if (length <= 0 || length > 100000) // Sanity check
@@ -366,6 +384,19 @@ char *lsp_code_lens(LSPTestContext *ctx) {
   return lsp_read_response(ctx, 1000);
 }
 
+char *lsp_completion(LSPTestContext *ctx, int line, int character) {
+  char params[512];
+  snprintf(params, sizeof(params),
+          "{\"textDocument\":{\"uri\":\"file:///test.kr\"},"
+          "\"position\":{\"line\":%d,\"character\":%d}}",
+          line, character);
+
+  if (!lsp_send_request(ctx, "textDocument/completion", params, 10))
+    return NULL;
+
+  return lsp_read_response(ctx, 1000);
+}
+
 char *lsp_extract_json_value(const char *json, const char *key) {
   // Simple JSON value extraction (for testing)
   char pattern[256];
@@ -427,4 +458,3 @@ bool lsp_is_valid_json(const char *response) {
   // Basic check: starts with { or [
   return response[0] == '{' || response[0] == '[' || response[0] == 'n'; // null
 }
-

--- a/tests/lsp/test_lsp_framework.h
+++ b/tests/lsp/test_lsp_framework.h
@@ -62,6 +62,9 @@ char *lsp_workspace_symbol(LSPTestContext *ctx, const char *query);
 // Send codeLens request
 char *lsp_code_lens(LSPTestContext *ctx);
 
+// Send completion request
+char *lsp_completion(LSPTestContext *ctx, int line, int character);
+
 // Helper to extract JSON value from response
 char *lsp_extract_json_value(const char *json, const char *key);
 
@@ -72,4 +75,3 @@ bool lsp_response_contains(const char *response, const char *substring);
 bool lsp_is_valid_json(const char *response);
 
 #endif // TEST_LSP_FRAMEWORK_H
-

--- a/tests/unit/test_vm.c
+++ b/tests/unit/test_vm.c
@@ -209,6 +209,90 @@ TEST(vm_execute_function) {
   vm_free(vm);
 }
 
+TEST(vm_builtin_filter_basic) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "set nums to list 1, 2, 3, 4, 5\n"
+      "set evens to call filter with nums, function with x: return x mod 2 is equal 0");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_INT_EQ(result, 0);
+
+  KronosValue *evens = vm_get_global(vm, "evens");
+  ASSERT_PTR_NOT_NULL(evens);
+  ASSERT_INT_EQ(evens->type, VAL_LIST);
+  ASSERT_EQ(evens->as.list.count, 2);
+  ASSERT_DOUBLE_EQ(evens->as.list.items[0]->as.number, 2.0);
+  ASSERT_DOUBLE_EQ(evens->as.list.items[1]->as.number, 4.0);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_builtin_map_basic) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "set nums to list 1, 2, 3\n"
+      "set doubled to call map with nums, function with x: return x times 2");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_INT_EQ(result, 0);
+
+  KronosValue *doubled = vm_get_global(vm, "doubled");
+  ASSERT_PTR_NOT_NULL(doubled);
+  ASSERT_INT_EQ(doubled->type, VAL_LIST);
+  ASSERT_EQ(doubled->as.list.count, 3);
+  ASSERT_DOUBLE_EQ(doubled->as.list.items[0]->as.number, 2.0);
+  ASSERT_DOUBLE_EQ(doubled->as.list.items[1]->as.number, 4.0);
+  ASSERT_DOUBLE_EQ(doubled->as.list.items[2]->as.number, 6.0);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_builtin_map_requires_list_argument) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "set bad to call map with \"hello\", function with x: return x");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_NE(result, 0);
+  ASSERT_PTR_NOT_NULL(vm->last_error_message);
+  ASSERT_TRUE(strstr(vm->last_error_message,
+                     "Function 'map' requires a list argument") != NULL);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_builtin_filter_callback_arity_error) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "set nums to list 1, 2, 3\n"
+      "set bad to call filter with nums, function with a, b: return a plus b");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_NE(result, 0);
+  ASSERT_PTR_NOT_NULL(vm->last_error_message);
+  ASSERT_TRUE(strstr(vm->last_error_message,
+                     "Function 'filter callback' requires at least 2 argument") != NULL);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
 TEST(vm_get_undefined_variable) {
   KronosVM *vm = vm_new();
   ASSERT_PTR_NOT_NULL(vm);

--- a/website/content/docs/api/collection-functions.mdx
+++ b/website/content/docs/api/collection-functions.mdx
@@ -43,6 +43,32 @@ set sorted_words to call sort with words  # Returns ["apple", "banana", "zebra"]
 - Works with numbers or strings, but all elements must be the same type
 - Sorting is done in ascending order
 
+### filter
+
+Return a new list containing only elements where the callback returns a truthy value.
+
+**Syntax:** `call filter with list, callback`
+
+**Example:**
+```kronos
+set numbers to list 1, 2, 3, 4, 5
+set evens to call filter with numbers, function with x: return x mod 2 is equal 0
+# evens -> [2, 4]
+```
+
+### map
+
+Return a new list where each element is transformed by the callback.
+
+**Syntax:** `call map with list, callback`
+
+**Example:**
+```kronos
+set numbers to list 1, 2, 3
+set doubled to call map with numbers, function with x: return x times 2
+# doubled -> [2, 4, 6]
+```
+
 ## Length
 
 ### len
@@ -127,4 +153,3 @@ print sorted
 print "Descending:"
 print descending
 ```
-

--- a/website/content/docs/roadmap.mdx
+++ b/website/content/docs/roadmap.mdx
@@ -322,7 +322,7 @@ set q, r to call divide_with_remainder with 10, 3
 - Multi-type support: `as number or string`
 </Accordion>
 
-<Accordion title="Higher-Order Functions">
+<Accordion title="Higher-Order Functions ✓">
 ```kronos
 set evens to filter numbers with function with x:
     return x mod 2 is equal 0


### PR DESCRIPTION
## Summary

Add higher-order list utilities `filter` and `map` across the runtime, LSP, tests, and documentation.

## Changes

- Add VM built-ins for `filter` and `map`, including callback execution, truthy filtering behavior, and argument validation for list and function inputs.
- Update parsing and LSP support so `filter` and `map` are recognized in function calls, completion items, argument-count handling, and list-argument diagnostics.
- Add unit, integration, and LSP coverage for successful usage plus invalid list, invalid callback, and callback arity error cases.
- Update the README, roadmap, and website docs to document `filter`/`map` usage and mark the higher-order list utilities roadmap item as completed.

## Testing

Ran `./scripts/run_tests.sh` and `make test-lsp`; both passed.

- [x] All existing tests pass
- [x] New tests added (if applicable)
- [ ] Examples updated (if applicable)
- [ ] Memory leak checks pass (if applicable)

## Documentation

Updated README, roadmap, and website docs with `filter` and `map` syntax, examples, and roadmap status.

- [x] Examples updated (if applicable)
- [x] README/docs updated (if applicable)

## Breaking Changes

None
