### PR TITLE
feat: complete type system enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A high-performance programming language built in C with human-readable syntax, f
 
 - **Human-Readable Syntax**: Natural language keywords like `set`, `let`, `to`, `print`, `is equal`, `greater than`, etc.
 - **Mutable & Immutable Variables**: Choose between `let` (mutable) and `set` (immutable)
-- **Optional Type Annotations**: Enforce types with the `as` keyword
+- **Optional Type Annotations**: Enforce primitive, generic, union, and alias types with `as`
 - **F-Strings**: Formatted string literals with expression interpolation (`f"Hello, {name}!"`)
 - **String Operations**: Concatenation, indexing, slicing, and comprehensive built-in functions
 - **Lists & Arrays**: Keyword and bracket list literals, list comprehensions, indexing, slicing, and iteration
@@ -88,6 +88,11 @@ let counter to counter plus 1  # Can reassign
 # Type annotations
 let age to 25 as number
 set name to "Alice" as string
+let scores to list 95, 87, 92 as list<number>
+let value to 42 as number or string
+
+type Point to map x: number, y: number
+set origin to map x: 0, y: 0 as Point
 
 # Data types
 set isActive to true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -290,11 +290,11 @@ This document outlines the planned features and release schedule for Kronos.
   - `case` branches are checked top to bottom
   - `default` is optional, but must appear last when present
 
-- **Type System Enhancements**
+- ✅ **Type System Enhancements** - Generic/union/alias support (completed)
 
-  - Generic types: `list<number>`, `map<string, number>`
-  - Type aliases: `type Point to map x: number, y: number`
-  - Multi-type support: `as number or string`
+  - ✅ Generic types: `list<number>`, `map<string, number>`
+  - ✅ Type aliases: `type Point to map x: number, y: number`
+  - ✅ Multi-type support: `as number or string`
 
 - **Debugging Support**
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -3395,6 +3395,11 @@ static void compile_statement(Compiler *c, const ASTNode *node) {
     compile_return_statement(c, node);
     break;
 
+  case AST_TYPE_ALIAS:
+    // Type aliases are compile-time metadata used for annotations only.
+    // They do not produce runtime bytecode.
+    break;
+
   // Expression nodes can be used as statements (for REPL expression evaluation)
   // Compile the expression and leave the value on the stack
   case AST_NUMBER:

--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -15,6 +15,7 @@
 
 #include "runtime.h"
 #include "gc.h"
+#include <ctype.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -1706,69 +1707,413 @@ KronosValue *string_intern(const char *str, size_t len) {
   return value_new_string(str, len);
 }
 
-/**
- * @brief Check if a value matches a type name
- *
- * Used for type annotations and type checking. Supports:
- * - "number" for VAL_NUMBER
- * - "string" for VAL_STRING
- * - "boolean" for VAL_BOOL
- * - "null" for VAL_NIL
- *
- * @param val Value to check
- * @param type_name Type name string (e.g., "number", "string")
- * @return true if value matches the type, false otherwise
- */
-bool value_is_type(KronosValue *val, const char *type_name) {
-  if (!val || !type_name)
-    return false;
+#define TYPE_MATCH_MAX_DEPTH 64
 
-  // Optimize by checking first character and length before strcmp
-  // This eliminates most comparisons quickly without needing full string
-  // comparison
-  char first = type_name[0];
-  size_t len = strlen(type_name);
-
-  switch (first) {
-  case 'b':
-    if (len == 7 && strcmp(type_name, "boolean") == 0)
-      return val->type == VAL_BOOL;
-    break;
-  case 'c':
-    if (len == 7 && strcmp(type_name, "channel") == 0)
-      return val->type == VAL_CHANNEL;
-    break;
-  case 'f':
-    if (len == 8 && strcmp(type_name, "function") == 0)
-      return val->type == VAL_FUNCTION;
-    break;
-  case 'l':
-    if (len == 4 && strcmp(type_name, "list") == 0)
-      return val->type == VAL_LIST;
-    break;
-  case 'm':
-    if (len == 3 && strcmp(type_name, "map") == 0)
-      return val->type == VAL_MAP;
-    break;
-  case 'n':
-    if (len == 6 && strcmp(type_name, "number") == 0)
-      return val->type == VAL_NUMBER;
-    else if (len == 4 && strcmp(type_name, "null") == 0)
-      return val->type == VAL_NIL;
-    break;
-  case 'r':
-    if (len == 5 && strcmp(type_name, "range") == 0)
-      return val->type == VAL_RANGE;
-    break;
-  case 's':
-    if (len == 6 && strcmp(type_name, "string") == 0)
-      return val->type == VAL_STRING;
-    break;
-  case 't':
-    if (len == 5 && strcmp(type_name, "tuple") == 0)
-      return val->type == VAL_TUPLE;
-    break;
+static char *type_trim_dup(const char *s, size_t len) {
+  if (!s) {
+    return NULL;
   }
 
+  size_t start = 0;
+  while (start < len && isspace((unsigned char)s[start])) {
+    start++;
+  }
+
+  size_t end = len;
+  while (end > start && isspace((unsigned char)s[end - 1])) {
+    end--;
+  }
+
+  size_t out_len = end - start;
+  char *out = malloc(out_len + 1);
+  if (!out) {
+    return NULL;
+  }
+  memcpy(out, s + start, out_len);
+  out[out_len] = '\0';
+  return out;
+}
+
+static bool parse_generic_inner(const char *type_name, const char *base,
+                                char **inner_out) {
+  if (!type_name || !base || !inner_out) {
+    return false;
+  }
+  *inner_out = NULL;
+
+  size_t base_len = strlen(base);
+  size_t type_len = strlen(type_name);
+  if (type_len <= base_len + 2) {
+    return false;
+  }
+  if (strncmp(type_name, base, base_len) != 0 || type_name[base_len] != '<') {
+    return false;
+  }
+
+  int depth = 1;
+  size_t close_idx = SIZE_MAX;
+  for (size_t i = base_len + 1; i < type_len; i++) {
+    char c = type_name[i];
+    if (c == '<') {
+      depth++;
+    } else if (c == '>') {
+      depth--;
+      if (depth == 0) {
+        close_idx = i;
+        break;
+      }
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+
+  if (close_idx == SIZE_MAX || close_idx != type_len - 1) {
+    return false;
+  }
+
+  *inner_out =
+      type_trim_dup(type_name + base_len + 1, close_idx - (base_len + 1));
+  return *inner_out != NULL;
+}
+
+static bool find_top_level_char(const char *s, char target, size_t *idx_out) {
+  if (!s) {
+    return false;
+  }
+
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t len = strlen(s);
+  for (size_t i = 0; i < len; i++) {
+    char c = s[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+    if (c == target && angle_depth == 0 && brace_depth == 0) {
+      if (idx_out) {
+        *idx_out = i;
+      }
+      return true;
+    }
+  }
   return false;
+}
+
+static bool value_is_base_type(KronosValue *val, const char *type_name) {
+  if (!val || !type_name) {
+    return false;
+  }
+
+  if (strcmp(type_name, "number") == 0) {
+    return val->type == VAL_NUMBER;
+  }
+  if (strcmp(type_name, "string") == 0) {
+    return val->type == VAL_STRING;
+  }
+  if (strcmp(type_name, "boolean") == 0 || strcmp(type_name, "bool") == 0) {
+    return val->type == VAL_BOOL;
+  }
+  if (strcmp(type_name, "null") == 0) {
+    return val->type == VAL_NIL;
+  }
+  if (strcmp(type_name, "list") == 0) {
+    return val->type == VAL_LIST;
+  }
+  if (strcmp(type_name, "map") == 0) {
+    return val->type == VAL_MAP;
+  }
+  if (strcmp(type_name, "range") == 0) {
+    return val->type == VAL_RANGE;
+  }
+  if (strcmp(type_name, "tuple") == 0) {
+    return val->type == VAL_TUPLE;
+  }
+  if (strcmp(type_name, "function") == 0) {
+    return val->type == VAL_FUNCTION;
+  }
+  if (strcmp(type_name, "channel") == 0) {
+    return val->type == VAL_CHANNEL;
+  }
+  return false;
+}
+
+static bool value_is_type_expr(KronosValue *val, const char *type_name,
+                               int depth) {
+  if (!val || !type_name || depth > TYPE_MATCH_MAX_DEPTH) {
+    return false;
+  }
+
+  char *trimmed = type_trim_dup(type_name, strlen(type_name));
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed[0] == '\0') {
+    free(trimmed);
+    return false;
+  }
+
+  // Top-level union support: "number or string".
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t segment_start = 0;
+  bool saw_union = false;
+  size_t len = strlen(trimmed);
+  for (size_t i = 0; i < len; i++) {
+    char c = trimmed[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+
+    if (angle_depth == 0 && brace_depth == 0 && c == 'o' && i + 1 < len &&
+        trimmed[i + 1] == 'r' &&
+        (i == 0 || isspace((unsigned char)trimmed[i - 1])) &&
+        (i + 2 >= len || isspace((unsigned char)trimmed[i + 2]))) {
+      saw_union = true;
+      char *segment = type_trim_dup(trimmed + segment_start, i - segment_start);
+      if (!segment) {
+        free(trimmed);
+        return false;
+      }
+      bool matches = value_is_type_expr(val, segment, depth + 1);
+      free(segment);
+      if (matches) {
+        free(trimmed);
+        return true;
+      }
+
+      // Skip to next non-whitespace after "or"
+      i += 2;
+      while (i < len && isspace((unsigned char)trimmed[i])) {
+        i++;
+      }
+      if (i > 0) {
+        segment_start = i;
+        i--;
+      } else {
+        segment_start = i;
+      }
+    }
+  }
+
+  if (saw_union) {
+    char *segment =
+        type_trim_dup(trimmed + segment_start, len - segment_start);
+    if (!segment) {
+      free(trimmed);
+      return false;
+    }
+    bool matches = value_is_type_expr(val, segment, depth + 1);
+    free(segment);
+    free(trimmed);
+    return matches;
+  }
+
+  // Generic list<T>.
+  char *inner = NULL;
+  if (parse_generic_inner(trimmed, "list", &inner)) {
+    bool ok = true;
+    if (val->type != VAL_LIST) {
+      ok = false;
+    } else if (find_top_level_char(inner, ',', NULL)) {
+      ok = false;
+    } else {
+      for (size_t i = 0; i < val->as.list.count; i++) {
+        if (!value_is_type_expr(val->as.list.items[i], inner, depth + 1)) {
+          ok = false;
+          break;
+        }
+      }
+    }
+    free(inner);
+    free(trimmed);
+    return ok;
+  }
+
+  // Generic map<K, V>.
+  if (parse_generic_inner(trimmed, "map", &inner)) {
+    bool ok = true;
+    if (val->type != VAL_MAP) {
+      ok = false;
+    } else {
+      size_t comma_idx = 0;
+      if (!find_top_level_char(inner, ',', &comma_idx)) {
+        ok = false;
+      } else {
+        char *key_type = type_trim_dup(inner, comma_idx);
+        char *value_type = type_trim_dup(inner + comma_idx + 1,
+                                         strlen(inner) - comma_idx - 1);
+        if (!key_type || !value_type || key_type[0] == '\0' ||
+            value_type[0] == '\0') {
+          ok = false;
+        } else if (find_top_level_char(value_type, ',', NULL)) {
+          // map<K,V> only supports two top-level arguments.
+          ok = false;
+        } else {
+          MapEntry *entries = (MapEntry *)val->as.map.entries;
+          for (size_t i = 0; i < val->as.map.capacity; i++) {
+            if (!entries[i].key || entries[i].is_tombstone) {
+              continue;
+            }
+            if (!value_is_type_expr(entries[i].key, key_type, depth + 1) ||
+                !value_is_type_expr(entries[i].value, value_type, depth + 1)) {
+              ok = false;
+              break;
+            }
+          }
+        }
+        free(key_type);
+        free(value_type);
+      }
+    }
+    free(inner);
+    free(trimmed);
+    return ok;
+  }
+
+  // Structural map shape: map{x:number,y:number}.
+  size_t trimmed_len = strlen(trimmed);
+  if (trimmed_len >= 5 && strncmp(trimmed, "map{", 4) == 0 &&
+      trimmed[trimmed_len - 1] == '}') {
+    if (val->type != VAL_MAP) {
+      free(trimmed);
+      return false;
+    }
+
+    char *fields = type_trim_dup(trimmed + 4, trimmed_len - 5);
+    if (!fields) {
+      free(trimmed);
+      return false;
+    }
+    if (fields[0] == '\0') {
+      free(fields);
+      free(trimmed);
+      return true;
+    }
+
+    bool ok = true;
+    size_t fields_len = strlen(fields);
+    size_t field_start = 0;
+    int inner_angle_depth = 0;
+    int inner_brace_depth = 0;
+
+    for (size_t i = 0; i <= fields_len; i++) {
+      char c = (i < fields_len) ? fields[i] : ',';
+      if (i < fields_len) {
+        if (c == '<') {
+          inner_angle_depth++;
+          continue;
+        }
+        if (c == '>') {
+          inner_angle_depth--;
+          continue;
+        }
+        if (c == '{') {
+          inner_brace_depth++;
+          continue;
+        }
+        if (c == '}') {
+          inner_brace_depth--;
+          continue;
+        }
+      }
+
+      if (c == ',' && inner_angle_depth == 0 && inner_brace_depth == 0) {
+        char *field =
+            type_trim_dup(fields + field_start, i - field_start);
+        if (!field || field[0] == '\0') {
+          free(field);
+          ok = false;
+          break;
+        }
+
+        size_t colon_idx = 0;
+        if (!find_top_level_char(field, ':', &colon_idx)) {
+          free(field);
+          ok = false;
+          break;
+        }
+
+        char *field_name = type_trim_dup(field, colon_idx);
+        char *field_type = type_trim_dup(field + colon_idx + 1,
+                                         strlen(field) - colon_idx - 1);
+        free(field);
+
+        if (!field_name || !field_type || field_name[0] == '\0' ||
+            field_type[0] == '\0') {
+          free(field_name);
+          free(field_type);
+          ok = false;
+          break;
+        }
+
+        KronosValue *key = value_new_string(field_name, strlen(field_name));
+        if (!key) {
+          free(field_name);
+          free(field_type);
+          ok = false;
+          break;
+        }
+        KronosValue *field_value = map_get(val, key);
+        value_release(key);
+
+        if (!field_value ||
+            !value_is_type_expr(field_value, field_type, depth + 1)) {
+          free(field_name);
+          free(field_type);
+          ok = false;
+          break;
+        }
+
+        free(field_name);
+        free(field_type);
+        field_start = i + 1;
+      }
+    }
+
+    free(fields);
+    free(trimmed);
+    return ok;
+  }
+
+  bool result = value_is_base_type(val, trimmed);
+  free(trimmed);
+  return result;
+}
+
+/**
+ * @brief Check if a value matches a type expression.
+ *
+ * Supports primitive names (`number`, `string`, ...), unions
+ * (`number or string`), generics (`list<number>`, `map<string, number>`), and
+ * structural map shapes (`map{x:number,y:number}`).
+ */
+bool value_is_type(KronosValue *val, const char *type_name) {
+  return value_is_type_expr(val, type_name, 0);
 }

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -103,6 +103,10 @@ typedef struct {
                              protection */
   ParseError **error_out; /**< Optional pointer to error output (for structured
                              errors) */
+  char **type_alias_names;   /**< Type alias names declared in the document */
+  char **type_alias_targets; /**< Canonical alias targets (same index as names) */
+  size_t type_alias_count;
+  size_t type_alias_capacity;
 } Parser;
 
 // Forward declarations
@@ -128,6 +132,10 @@ static Parser *parser_new(TokenArray *tokens, ParseError **error_out) {
   p->pos = 0;
   p->recursion_depth = 0;
   p->error_out = error_out;
+  p->type_alias_names = NULL;
+  p->type_alias_targets = NULL;
+  p->type_alias_count = 0;
+  p->type_alias_capacity = 0;
   return p;
 }
 
@@ -141,6 +149,12 @@ static Parser *parser_new(TokenArray *tokens, ParseError **error_out) {
  */
 static void parser_free(Parser *p) {
   if (p) {
+    for (size_t i = 0; i < p->type_alias_count; i++) {
+      free(p->type_alias_names[i]);
+      free(p->type_alias_targets[i]);
+    }
+    free(p->type_alias_names);
+    free(p->type_alias_targets);
     free(p);
   }
 }
@@ -273,6 +287,10 @@ static const char *token_type_name(TokenType type) {
     return "LBRACKET";
   case TOK_RBRACKET:
     return "RBRACKET";
+  case TOK_LANGLE:
+    return "LANGLE";
+  case TOK_RANGLE:
+    return "RANGLE";
   case TOK_NEWLINE:
     return "NEWLINE";
   case TOK_INDENT:
@@ -478,6 +496,7 @@ static ASTNode *parse_try(Parser *p, int indent);
 static ASTNode *parse_raise(Parser *p, int indent);
 static ASTNode *parse_match(Parser *p, int indent);
 static ASTNode *parse_lambda(Parser *p);
+static ASTNode *parse_type_alias(Parser *p, int indent);
 
 // Helper functions for parse_try
 static bool try_parse_catch_block(Parser *p, int indent, ASTNode *try_node,
@@ -519,6 +538,7 @@ static bool token_starts_expression(const Token *tok);
 static ASTNode *assignment_parse_index(Parser *p, int indent, Token *name);
 static ASTNode *assignment_parse_regular(Parser *p, int indent, Token *name,
                                          bool is_mutable, Token *start_tok);
+static char *parse_type_expression(Parser *p);
 
 // Result structure for extended parameter parsing
 typedef struct {
@@ -656,7 +676,16 @@ static ASTNode *fstring_parse_expression(const char *content, size_t expr_start,
   }
 
   // Create a temporary parser for the expression
-  Parser expr_parser = {expr_tokens, 0, 0, NULL};
+  Parser expr_parser = {
+      .tokens = expr_tokens,
+      .pos = 0,
+      .recursion_depth = 0,
+      .error_out = NULL,
+      .type_alias_names = NULL,
+      .type_alias_targets = NULL,
+      .type_alias_count = 0,
+      .type_alias_capacity = 0,
+  };
 
   // Skip INDENT token if present (tokenizer adds it for each line)
   if (expr_parser.pos < expr_tokens->count &&
@@ -2205,6 +2234,418 @@ static ASTNode *parse_condition(Parser *p) {
   return parse_expression(p);
 }
 
+static const char *parser_find_type_alias(const Parser *p, const char *name) {
+  if (!p || !name) {
+    return NULL;
+  }
+  for (size_t i = 0; i < p->type_alias_count; i++) {
+    if (p->type_alias_names[i] &&
+        strcmp(p->type_alias_names[i], name) == 0) {
+      return p->type_alias_targets[i];
+    }
+  }
+  return NULL;
+}
+
+static bool parser_is_reserved_type_name(const char *name) {
+  if (!name) {
+    return true;
+  }
+  return strcmp(name, "number") == 0 || strcmp(name, "string") == 0 ||
+         strcmp(name, "boolean") == 0 || strcmp(name, "bool") == 0 ||
+         strcmp(name, "null") == 0 || strcmp(name, "list") == 0 ||
+         strcmp(name, "map") == 0 || strcmp(name, "range") == 0 ||
+         strcmp(name, "tuple") == 0 || strcmp(name, "function") == 0 ||
+         strcmp(name, "channel") == 0;
+}
+
+static bool parser_add_type_alias(Parser *p, const char *name,
+                                  const char *target_type) {
+  if (!p || !name || !target_type) {
+    return false;
+  }
+
+  if (parser_is_reserved_type_name(name)) {
+    parser_set_error(p, "Type alias name cannot shadow built-in type names");
+    return false;
+  }
+
+  if (parser_find_type_alias(p, name) != NULL) {
+    parser_set_error(p, "Type alias already defined");
+    return false;
+  }
+
+  if (p->type_alias_count >= p->type_alias_capacity) {
+    size_t new_capacity = p->type_alias_capacity == 0 ? 8 : p->type_alias_capacity * 2;
+    char **new_names =
+        realloc(p->type_alias_names, sizeof(char *) * new_capacity);
+    if (!new_names) {
+      parser_set_error(p, "Failed to allocate type alias table");
+      return false;
+    }
+    p->type_alias_names = new_names;
+
+    char **new_targets =
+        realloc(p->type_alias_targets, sizeof(char *) * new_capacity);
+    if (!new_targets) {
+      parser_set_error(p, "Failed to allocate type alias table");
+      return false;
+    }
+    p->type_alias_targets = new_targets;
+    p->type_alias_capacity = new_capacity;
+  }
+
+  char *name_copy = strdup(name);
+  char *target_copy = strdup(target_type);
+  if (!name_copy || !target_copy) {
+    free(name_copy);
+    free(target_copy);
+    parser_set_error(p, "Failed to allocate type alias");
+    return false;
+  }
+
+  p->type_alias_names[p->type_alias_count] = name_copy;
+  p->type_alias_targets[p->type_alias_count] = target_copy;
+  p->type_alias_count++;
+  return true;
+}
+
+static bool type_builder_append(char **buf, size_t *len, size_t *cap,
+                                const char *text) {
+  if (!buf || !len || !cap || !text) {
+    return false;
+  }
+
+  size_t add_len = strlen(text);
+  if (*len + add_len + 1 > *cap) {
+    size_t new_cap = *cap == 0 ? 64 : *cap;
+    while (*len + add_len + 1 > new_cap) {
+      new_cap *= 2;
+    }
+    char *new_buf = realloc(*buf, new_cap);
+    if (!new_buf) {
+      return false;
+    }
+    *buf = new_buf;
+    *cap = new_cap;
+  }
+
+  memcpy(*buf + *len, text, add_len);
+  *len += add_len;
+  (*buf)[*len] = '\0';
+  return true;
+}
+
+static bool token_is_type_identifier(const Token *tok) {
+  if (!tok) {
+    return false;
+  }
+
+  switch (tok->type) {
+  case TOK_NAME:
+  case TOK_LIST:
+  case TOK_MAP:
+  case TOK_RANGE:
+  case TOK_FUNCTION:
+  case TOK_NULL:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static const char *token_type_identifier_text(const Token *tok) {
+  if (!tok) {
+    return NULL;
+  }
+
+  switch (tok->type) {
+  case TOK_NAME:
+    return tok->text;
+  case TOK_LIST:
+    return "list";
+  case TOK_MAP:
+    return "map";
+  case TOK_RANGE:
+    return "range";
+  case TOK_FUNCTION:
+    return "function";
+  case TOK_NULL:
+    return "null";
+  default:
+    return NULL;
+  }
+}
+
+static char *parse_type_primary(Parser *p) {
+  Token *tok = peek(p, 0);
+  if (!tok || !token_is_type_identifier(tok)) {
+    parser_set_error(p, "Expected type name in type annotation");
+    return NULL;
+  }
+
+  // Special shape syntax for map aliases:
+  // type Point to map x: number, y: number
+  if (tok->type == TOK_MAP) {
+    consume_any(p); // consume "map"
+
+    Token *next = peek(p, 0);
+    Token *next2 = peek(p, 1);
+    bool is_shape =
+        next && next2 && next->type == TOK_NAME && next2->type == TOK_COLON;
+    if (is_shape) {
+      char *buf = NULL;
+      size_t len = 0, cap = 0;
+      if (!type_builder_append(&buf, &len, &cap, "map{")) {
+        free(buf);
+        parser_set_error(p, "Failed to allocate map type shape");
+        return NULL;
+      }
+
+      bool first_field = true;
+      while (true) {
+        Token *field_tok = consume(p, TOK_NAME);
+        if (!field_tok) {
+          free(buf);
+          return NULL;
+        }
+        if (!consume(p, TOK_COLON)) {
+          free(buf);
+          return NULL;
+        }
+
+        char *field_type = parse_type_expression(p);
+        if (!field_type) {
+          free(buf);
+          return NULL;
+        }
+
+        if (!first_field &&
+            !type_builder_append(&buf, &len, &cap, ",")) {
+          free(buf);
+          free(field_type);
+          parser_set_error(p, "Failed to allocate map type shape");
+          return NULL;
+        }
+        first_field = false;
+
+        if (!type_builder_append(&buf, &len, &cap, field_tok->text) ||
+            !type_builder_append(&buf, &len, &cap, ":") ||
+            !type_builder_append(&buf, &len, &cap, field_type)) {
+          free(buf);
+          free(field_type);
+          parser_set_error(p, "Failed to allocate map type shape");
+          return NULL;
+        }
+        free(field_type);
+
+        Token *comma = peek(p, 0);
+        if (!comma || comma->type != TOK_COMMA) {
+          break;
+        }
+        consume_any(p);
+      }
+
+      if (!type_builder_append(&buf, &len, &cap, "}")) {
+        free(buf);
+        parser_set_error(p, "Failed to allocate map type shape");
+        return NULL;
+      }
+
+      return buf;
+    }
+
+    // Parse generic map<K, V> if present.
+    next = peek(p, 0);
+    if (next && next->type == TOK_LANGLE) {
+      consume_any(p); // consume '<'
+
+      char *key_type = parse_type_expression(p);
+      if (!key_type) {
+        return NULL;
+      }
+
+      if (!consume(p, TOK_COMMA)) {
+        free(key_type);
+        return NULL;
+      }
+
+      char *value_type = parse_type_expression(p);
+      if (!value_type) {
+        free(key_type);
+        return NULL;
+      }
+
+      if (!consume(p, TOK_RANGLE)) {
+        free(key_type);
+        free(value_type);
+        return NULL;
+      }
+
+      size_t out_len = strlen("map<,>") + strlen(key_type) + strlen(value_type) + 1;
+      char *out = malloc(out_len);
+      if (!out) {
+        free(key_type);
+        free(value_type);
+        parser_set_error(p, "Failed to allocate generic map type");
+        return NULL;
+      }
+      snprintf(out, out_len, "map<%s,%s>", key_type, value_type);
+      free(key_type);
+      free(value_type);
+      return out;
+    }
+
+    return strdup("map");
+  }
+
+  consume_any(p);
+  const char *base_text = token_type_identifier_text(tok);
+  if (!base_text) {
+    parser_set_error(p, "Expected type name in type annotation");
+    return NULL;
+  }
+
+  // Parse generic list<T> and generic forms for named types.
+  Token *next = peek(p, 0);
+  if (next && next->type == TOK_LANGLE) {
+    consume_any(p); // consume '<'
+
+    char **generic_args = NULL;
+    size_t arg_count = 0;
+    size_t arg_cap = 0;
+
+    while (true) {
+      char *arg = parse_type_expression(p);
+      if (!arg) {
+        for (size_t i = 0; i < arg_count; i++) {
+          free(generic_args[i]);
+        }
+        free(generic_args);
+        return NULL;
+      }
+
+      if (arg_count >= arg_cap) {
+        size_t new_cap = arg_cap == 0 ? 4 : arg_cap * 2;
+        char **new_args = realloc(generic_args, sizeof(char *) * new_cap);
+        if (!new_args) {
+          for (size_t i = 0; i < arg_count; i++) {
+            free(generic_args[i]);
+          }
+          free(generic_args);
+          free(arg);
+          parser_set_error(p, "Failed to allocate generic type arguments");
+          return NULL;
+        }
+        generic_args = new_args;
+        arg_cap = new_cap;
+      }
+      generic_args[arg_count++] = arg;
+
+      Token *comma = peek(p, 0);
+      if (!comma || comma->type != TOK_COMMA) {
+        break;
+      }
+      consume_any(p);
+    }
+
+    if (!consume(p, TOK_RANGLE)) {
+      for (size_t i = 0; i < arg_count; i++) {
+        free(generic_args[i]);
+      }
+      free(generic_args);
+      return NULL;
+    }
+
+    if (strcmp(base_text, "list") == 0 && arg_count != 1) {
+      for (size_t i = 0; i < arg_count; i++) {
+        free(generic_args[i]);
+      }
+      free(generic_args);
+      parser_set_error(p, "Generic list type requires exactly one type argument");
+      return NULL;
+    }
+    if (strcmp(base_text, "map") == 0 && arg_count != 2) {
+      for (size_t i = 0; i < arg_count; i++) {
+        free(generic_args[i]);
+      }
+      free(generic_args);
+      parser_set_error(p, "Generic map type requires exactly two type arguments");
+      return NULL;
+    }
+
+    char *buf = NULL;
+    size_t len = 0, cap = 0;
+    bool ok = type_builder_append(&buf, &len, &cap, base_text) &&
+              type_builder_append(&buf, &len, &cap, "<");
+    for (size_t i = 0; ok && i < arg_count; i++) {
+      if (i > 0) {
+        ok = type_builder_append(&buf, &len, &cap, ",");
+      }
+      if (ok) {
+        ok = type_builder_append(&buf, &len, &cap, generic_args[i]);
+      }
+    }
+    if (ok) {
+      ok = type_builder_append(&buf, &len, &cap, ">");
+    }
+
+    for (size_t i = 0; i < arg_count; i++) {
+      free(generic_args[i]);
+    }
+    free(generic_args);
+
+    if (!ok) {
+      free(buf);
+      parser_set_error(p, "Failed to allocate generic type annotation");
+      return NULL;
+    }
+    return buf;
+  }
+
+  if (tok->type == TOK_NAME) {
+    const char *alias_target = parser_find_type_alias(p, base_text);
+    if (alias_target) {
+      return strdup(alias_target);
+    }
+  }
+
+  return strdup(base_text);
+}
+
+static char *parse_type_expression(Parser *p) {
+  char *left = parse_type_primary(p);
+  if (!left) {
+    return NULL;
+  }
+
+  while (peek(p, 0) && peek(p, 0)->type == TOK_OR) {
+    consume_any(p); // consume 'or'
+
+    char *right = parse_type_primary(p);
+    if (!right) {
+      free(left);
+      return NULL;
+    }
+
+    size_t out_len =
+        strlen(left) + strlen(" or ") + strlen(right) + 1;
+    char *combined = malloc(out_len);
+    if (!combined) {
+      free(left);
+      free(right);
+      parser_set_error(p, "Failed to allocate union type annotation");
+      return NULL;
+    }
+    snprintf(combined, out_len, "%s or %s", left, right);
+    free(left);
+    free(right);
+    left = combined;
+  }
+
+  return left;
+}
+
 /**
  * @brief Parse an index assignment
  *
@@ -2300,15 +2741,8 @@ static ASTNode *assignment_parse_regular(Parser *p, int indent, Token *name,
   Token *next = peek(p, 0);
   if (next && next->type == TOK_AS) {
     consume(p, TOK_AS);
-    Token *type_tok = consume(p, TOK_NAME);
-    if (!type_tok) {
-      ast_node_free(value);
-      return NULL;
-    }
-    type_name = strdup(type_tok->text);
+    type_name = parse_type_expression(p);
     if (!type_name) {
-      fprintf(stderr,
-              "Memory allocation failed for assignment type annotation\n");
       ast_node_free(value);
       return NULL;
     }
@@ -4613,6 +5047,73 @@ static ASTNode *parse_import(Parser *p, int indent) {
 }
 
 /**
+ * @brief Parse a type alias declaration
+ *
+ * Parses: type AliasName to TypeExpression
+ *
+ * @param p Parser state
+ * @param indent Indentation level of this statement
+ * @return AST node for type alias declaration, or NULL on error
+ */
+static ASTNode *parse_type_alias(Parser *p, int indent) {
+  Token *start_tok = peek(p, 0);
+  if (!start_tok || start_tok->type != TOK_NAME ||
+      strcmp(start_tok->text, "type") != 0) {
+    return NULL;
+  }
+
+  consume_any(p); // consume "type"
+
+  Token *alias_name_tok = consume(p, TOK_NAME);
+  if (!alias_name_tok) {
+    return NULL;
+  }
+
+  if (!consume(p, TOK_TO)) {
+    return NULL;
+  }
+
+  char *target_type = parse_type_expression(p);
+  if (!target_type) {
+    return NULL;
+  }
+
+  Token *next = peek(p, 0);
+  if (next && next->type == TOK_NEWLINE) {
+    consume_any(p);
+  } else if (!(next && (next->type == TOK_INDENT || next->type == TOK_EOF))) {
+    free(target_type);
+    parser_set_error(p, "Expected newline after type alias declaration");
+    return NULL;
+  }
+
+  if (!parser_add_type_alias(p, alias_name_tok->text, target_type)) {
+    free(target_type);
+    return NULL;
+  }
+
+  ASTNode *node = ast_node_new_checked(AST_TYPE_ALIAS);
+  if (!node) {
+    free(target_type);
+    return NULL;
+  }
+  ast_node_set_position(node, start_tok);
+  node->indent = indent;
+  node->as.type_alias.name = strdup(alias_name_tok->text);
+  node->as.type_alias.target_type = target_type;
+
+  if (!node->as.type_alias.name || !node->as.type_alias.target_type) {
+    free(node->as.type_alias.name);
+    free(node->as.type_alias.target_type);
+    free(node);
+    parser_set_error(p, "Failed to allocate type alias AST node");
+    return NULL;
+  }
+
+  return node;
+}
+
+/**
  * @brief Parse a break statement
  *
  * Parses: break
@@ -4696,6 +5197,10 @@ static ASTNode *parse_statement(Parser *p) {
 
   if (!tok) {
     return NULL;
+  }
+
+  if (tok->type == TOK_NAME && tok->text && strcmp(tok->text, "type") == 0) {
+    return parse_type_alias(p, indent);
   }
 
   switch (tok->type) {
@@ -5175,6 +5680,10 @@ void ast_node_free(ASTNode *node) {
     free(node->as.unpack_assign.names);
     ast_node_free(node->as.unpack_assign.value);
     break;
+  case AST_TYPE_ALIAS:
+    free(node->as.type_alias.name);
+    free(node->as.type_alias.target_type);
+    break;
   default:
     break;
   }
@@ -5269,6 +5778,8 @@ static const char *ast_node_type_name(ASTNodeType type) {
     return "TUPLE";
   case AST_UNPACK_ASSIGN:
     return "UNPACK_ASSIGN";
+  case AST_TYPE_ALIAS:
+    return "TYPE_ALIAS";
   default:
     return "UNKNOWN";
   }
@@ -5369,6 +5880,12 @@ static void ast_node_print_recursive(ASTNode *node, int indent) {
     }
     printf("\n");
     ast_node_print_recursive(node->as.assign.value, indent + 1);
+    break;
+  case AST_TYPE_ALIAS:
+    printf(": %s -> %s\n",
+           node->as.type_alias.name ? node->as.type_alias.name : "(null)",
+           node->as.type_alias.target_type ? node->as.type_alias.target_type
+                                           : "(null)");
     break;
   case AST_PRINT:
     printf("\n");

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -38,6 +38,7 @@ typedef enum {
   AST_LAMBDA,       // Anonymous function expression
   AST_TUPLE,        // Tuple expression: a, b, c
   AST_UNPACK_ASSIGN, // Destructuring assignment: set x, y to expr
+  AST_TYPE_ALIAS,   // Type alias declaration: type Name to ...
 } ASTNodeType;
 
 typedef struct ASTNode ASTNode;
@@ -96,6 +97,12 @@ struct ASTNode {
       bool is_mutable; // true for 'let', false for 'set'
       char *type_name; // Optional type annotation (NULL if not specified)
     } assign;
+
+    // Type alias: type Name to TypeExpr
+    struct {
+      char *name;
+      char *target_type;
+    } type_alias;
 
     // Print statement
     struct {

--- a/src/frontend/tokenizer.c
+++ b/src/frontend/tokenizer.c
@@ -181,7 +181,7 @@ static const char *token_type_names[] = {
     "DIVIDED", "BY",       "MOD",      "DELETE",   "TRY",      "CATCH",
     "FINALLY", "RAISE",    "MATCH",    "CASE",     "DEFAULT",  "NAME",
     "COLON",   "COMMA",    "ELLIPSIS", "LPAREN",   "RPAREN",   "LBRACKET",
-    "RBRACKET", "NEWLINE", "INDENT",   "EOF"};
+    "RBRACKET", "LANGLE",  "RANGLE",   "NEWLINE", "INDENT",   "EOF"};
 
 // Compile-time check to ensure array matches enum count
 // This will cause a compilation error if they don't match
@@ -204,6 +204,8 @@ static const char TOKEN_TEXT_LPAREN[] = "(";
 static const char TOKEN_TEXT_RPAREN[] = ")";
 static const char TOKEN_TEXT_LBRACKET[] = "[";
 static const char TOKEN_TEXT_RBRACKET[] = "]";
+static const char TOKEN_TEXT_LANGLE[] = "<";
+static const char TOKEN_TEXT_RANGLE[] = ">";
 static const char TOKEN_TEXT_NEWLINE[] = "\n";
 
 // Token array initial capacity - starts small and grows as needed
@@ -220,7 +222,8 @@ static bool is_static_token_text(const char *text) {
          text == TOKEN_TEXT_ELLIPSIS || text == TOKEN_TEXT_EQUALS ||
          text == TOKEN_TEXT_MINUS || text == TOKEN_TEXT_NEWLINE ||
          text == TOKEN_TEXT_LPAREN || text == TOKEN_TEXT_RPAREN ||
-         text == TOKEN_TEXT_LBRACKET || text == TOKEN_TEXT_RBRACKET;
+         text == TOKEN_TEXT_LBRACKET || text == TOKEN_TEXT_RBRACKET ||
+         text == TOKEN_TEXT_LANGLE || text == TOKEN_TEXT_RANGLE;
 }
 
 /**
@@ -797,6 +800,28 @@ static bool tokenize_line(TokenArray *arr, const char *line, int indent,
     if (line[col] == ']') {
       size_t token_col = indent + col + 1;
       Token tok = {TOK_RBRACKET, TOKEN_TEXT_RBRACKET, 1, 0, line_number,
+                   token_col};
+      if (!token_array_add(arr, tok, out_err, line_number, token_col)) {
+        return false;
+      }
+      col++;
+      continue;
+    }
+
+    if (line[col] == '<') {
+      size_t token_col = indent + col + 1;
+      Token tok = {TOK_LANGLE, TOKEN_TEXT_LANGLE, 1, 0, line_number,
+                   token_col};
+      if (!token_array_add(arr, tok, out_err, line_number, token_col)) {
+        return false;
+      }
+      col++;
+      continue;
+    }
+
+    if (line[col] == '>') {
+      size_t token_col = indent + col + 1;
+      Token tok = {TOK_RANGLE, TOKEN_TEXT_RANGLE, 1, 0, line_number,
                    token_col};
       if (!token_array_add(arr, tok, out_err, line_number, token_col)) {
         return false;

--- a/src/frontend/tokenizer.h
+++ b/src/frontend/tokenizer.h
@@ -70,6 +70,8 @@ typedef enum {
   TOK_RPAREN,
   TOK_LBRACKET,
   TOK_RBRACKET,
+  TOK_LANGLE,    // < for generic type annotations
+  TOK_RANGLE,    // > for generic type annotations
   TOK_NEWLINE,
   TOK_INDENT,
   TOK_EOF,

--- a/src/lsp/lsp.h
+++ b/src/lsp/lsp.h
@@ -29,6 +29,7 @@ typedef enum {
   SYMBOL_VARIABLE,  /**< Variable declaration (set/let) */
   SYMBOL_FUNCTION,  /**< Function definition */
   SYMBOL_PARAMETER, /**< Function parameter */
+  SYMBOL_TYPE_ALIAS, /**< Type alias declaration */
 } SymbolType;
 
 /**

--- a/src/lsp/lsp_completion.c
+++ b/src/lsp/lsp_completion.c
@@ -31,6 +31,7 @@ void handle_completion(const char *id, const char *body) {
       // Variable declarations
       {"set", "Immutable variable"},
       {"let", "Mutable variable"},
+      {"type", "Declare type alias (type Name to TypeExpr)"},
       {"to", "Assignment operator (set x to 5)"},
       {"as", "Type annotation (as number)"},
       // Control flow
@@ -211,11 +212,17 @@ void handle_completion(const char *id, const char *body) {
       const char *kind_str = "6"; // Variable
       if (sym->type == SYMBOL_FUNCTION)
         kind_str = "12"; // Function
+      else if (sym->type == SYMBOL_TYPE_ALIAS)
+        kind_str = "13"; // Type parameter-ish bucket for aliases
 
       char escaped[LSP_PATTERN_BUFFER_SIZE];
       json_escape(sym->name, escaped, sizeof(escaped));
-      const char *detail =
-          sym->type == SYMBOL_FUNCTION ? "User-defined function" : "Variable";
+      const char *detail = "Variable";
+      if (sym->type == SYMBOL_FUNCTION) {
+        detail = "User-defined function";
+      } else if (sym->type == SYMBOL_TYPE_ALIAS) {
+        detail = "Type alias";
+      }
       char escaped_detail[LSP_PATTERN_BUFFER_SIZE];
       json_escape(detail, escaped_detail, sizeof(escaped_detail));
 

--- a/src/lsp/lsp_diagnostics.c
+++ b/src/lsp/lsp_diagnostics.c
@@ -37,6 +37,34 @@ typedef struct {
 // Maximum recursion depth for type inference to prevent stack overflow
 #define MAX_TYPE_INFER_DEPTH 32
 
+static ExprType expr_type_from_annotation(const char *type_name) {
+  if (!type_name) {
+    return TYPE_UNKNOWN;
+  }
+  if (strcmp(type_name, "number") == 0) {
+    return TYPE_NUMBER;
+  }
+  if (strcmp(type_name, "string") == 0) {
+    return TYPE_STRING;
+  }
+  if (strcmp(type_name, "boolean") == 0 || strcmp(type_name, "bool") == 0) {
+    return TYPE_BOOL;
+  }
+  if (strcmp(type_name, "null") == 0) {
+    return TYPE_NULL;
+  }
+  if (strcmp(type_name, "range") == 0) {
+    return TYPE_RANGE;
+  }
+  if (strncmp(type_name, "list", 4) == 0) {
+    return TYPE_LIST;
+  }
+  if (strncmp(type_name, "map", 3) == 0) {
+    return TYPE_MAP;
+  }
+  return TYPE_UNKNOWN;
+}
+
 // Internal recursive version with depth tracking
 static ExprType infer_type_internal(ASTNode *node, Symbol *symbols, AST *ast,
                                     int depth) {
@@ -65,16 +93,10 @@ static ExprType infer_type_internal(ASTNode *node, Symbol *symbols, AST *ast,
   case AST_VAR: {
     Symbol *sym = find_symbol(node->as.var_name);
     if (sym && sym->type_name) {
-      if (strcmp(sym->type_name, "number") == 0)
-        return TYPE_NUMBER;
-      if (strcmp(sym->type_name, "string") == 0)
-        return TYPE_STRING;
-      if (strcmp(sym->type_name, "list") == 0)
-        return TYPE_LIST;
-      if (strcmp(sym->type_name, "map") == 0)
-        return TYPE_MAP;
-      if (strcmp(sym->type_name, "bool") == 0)
-        return TYPE_BOOL;
+      ExprType annotated = expr_type_from_annotation(sym->type_name);
+      if (annotated != TYPE_UNKNOWN) {
+        return annotated;
+      }
     }
     // If no explicit type annotation, try to infer from assigned value
     if (ast) {
@@ -150,6 +172,642 @@ static ExprType infer_type_internal(ASTNode *node, Symbol *symbols, AST *ast,
 // Public API wrapper - starts recursion with depth 0
 ExprType infer_type_with_ast(ASTNode *node, Symbol *symbols, AST *ast) {
   return infer_type_internal(node, symbols, ast, 0);
+}
+
+#define LSP_TYPE_MATCH_MAX_DEPTH 32
+
+static char *lsp_trim_dup(const char *s, size_t len) {
+  if (!s) {
+    return NULL;
+  }
+  size_t start = 0;
+  while (start < len && isspace((unsigned char)s[start])) {
+    start++;
+  }
+  size_t end = len;
+  while (end > start && isspace((unsigned char)s[end - 1])) {
+    end--;
+  }
+  size_t out_len = end - start;
+  char *out = malloc(out_len + 1);
+  if (!out) {
+    return NULL;
+  }
+  memcpy(out, s + start, out_len);
+  out[out_len] = '\0';
+  return out;
+}
+
+static bool lsp_find_top_level_char(const char *s, char target,
+                                    size_t *idx_out) {
+  if (!s) {
+    return false;
+  }
+
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t len = strlen(s);
+  for (size_t i = 0; i < len; i++) {
+    char c = s[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+    if (c == target && angle_depth == 0 && brace_depth == 0) {
+      if (idx_out) {
+        *idx_out = i;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool lsp_parse_generic_inner(const char *type_name, const char *base,
+                                    char **inner_out) {
+  if (!type_name || !base || !inner_out) {
+    return false;
+  }
+  *inner_out = NULL;
+
+  size_t base_len = strlen(base);
+  size_t type_len = strlen(type_name);
+  if (type_len <= base_len + 2) {
+    return false;
+  }
+  if (strncmp(type_name, base, base_len) != 0 || type_name[base_len] != '<') {
+    return false;
+  }
+
+  int depth = 1;
+  size_t close_idx = SIZE_MAX;
+  for (size_t i = base_len + 1; i < type_len; i++) {
+    char c = type_name[i];
+    if (c == '<') {
+      depth++;
+    } else if (c == '>') {
+      depth--;
+      if (depth == 0) {
+        close_idx = i;
+        break;
+      }
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+
+  if (close_idx == SIZE_MAX || close_idx != type_len - 1) {
+    return false;
+  }
+
+  *inner_out =
+      lsp_trim_dup(type_name + base_len + 1, close_idx - (base_len + 1));
+  return *inner_out != NULL;
+}
+
+static bool lsp_type_annotations_compatible(const char *expected,
+                                            const char *actual, int depth);
+
+static bool lsp_try_union_compat(const char *container, const char *other,
+                                 bool container_is_expected, int depth) {
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t start = 0;
+  size_t len = strlen(container);
+  bool saw_union = false;
+
+  for (size_t i = 0; i < len; i++) {
+    char c = container[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+    if (angle_depth == 0 && brace_depth == 0 && c == 'o' && i + 1 < len &&
+        container[i + 1] == 'r' &&
+        (i == 0 || isspace((unsigned char)container[i - 1])) &&
+        (i + 2 >= len || isspace((unsigned char)container[i + 2]))) {
+      saw_union = true;
+      char *segment = lsp_trim_dup(container + start, i - start);
+      if (!segment) {
+        return false;
+      }
+      bool ok = container_is_expected
+                    ? lsp_type_annotations_compatible(segment, other, depth + 1)
+                    : lsp_type_annotations_compatible(other, segment, depth + 1);
+      free(segment);
+
+      if (container_is_expected) {
+        if (ok) {
+          return true;
+        }
+      } else if (!ok) {
+        return false;
+      }
+
+      i += 2;
+      while (i < len && isspace((unsigned char)container[i])) {
+        i++;
+      }
+      if (i > 0) {
+        start = i;
+        i--;
+      } else {
+        start = i;
+      }
+    }
+  }
+
+  if (!saw_union) {
+    return false;
+  }
+
+  char *segment = lsp_trim_dup(container + start, len - start);
+  if (!segment) {
+    return false;
+  }
+  bool final_ok = container_is_expected
+                      ? lsp_type_annotations_compatible(segment, other, depth + 1)
+                      : lsp_type_annotations_compatible(other, segment, depth + 1);
+  free(segment);
+  return container_is_expected ? final_ok : final_ok;
+}
+
+static bool lsp_type_annotations_compatible(const char *expected,
+                                            const char *actual, int depth) {
+  if (!expected || !actual || depth > LSP_TYPE_MATCH_MAX_DEPTH) {
+    return false;
+  }
+
+  char *exp = lsp_trim_dup(expected, strlen(expected));
+  char *act = lsp_trim_dup(actual, strlen(actual));
+  if (!exp || !act) {
+    free(exp);
+    free(act);
+    return false;
+  }
+
+  if (strcmp(exp, act) == 0) {
+    free(exp);
+    free(act);
+    return true;
+  }
+
+  if ((strcmp(exp, "bool") == 0 && strcmp(act, "boolean") == 0) ||
+      (strcmp(exp, "boolean") == 0 && strcmp(act, "bool") == 0)) {
+    free(exp);
+    free(act);
+    return true;
+  }
+
+  if (lsp_try_union_compat(exp, act, true, depth)) {
+    free(exp);
+    free(act);
+    return true;
+  }
+
+  bool actual_union = false;
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t start = 0;
+  size_t len = strlen(act);
+  for (size_t i = 0; i < len; i++) {
+    char c = act[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+    if (angle_depth == 0 && brace_depth == 0 && c == 'o' && i + 1 < len &&
+        act[i + 1] == 'r' &&
+        (i == 0 || isspace((unsigned char)act[i - 1])) &&
+        (i + 2 >= len || isspace((unsigned char)act[i + 2]))) {
+      actual_union = true;
+      char *segment = lsp_trim_dup(act + start, i - start);
+      if (!segment) {
+        free(exp);
+        free(act);
+        return false;
+      }
+      bool ok = lsp_type_annotations_compatible(exp, segment, depth + 1);
+      free(segment);
+      if (!ok) {
+        free(exp);
+        free(act);
+        return false;
+      }
+      i += 2;
+      while (i < len && isspace((unsigned char)act[i])) {
+        i++;
+      }
+      if (i > 0) {
+        start = i;
+        i--;
+      } else {
+        start = i;
+      }
+    }
+  }
+  if (actual_union) {
+    char *segment = lsp_trim_dup(act + start, len - start);
+    if (!segment) {
+      free(exp);
+      free(act);
+      return false;
+    }
+    bool ok = lsp_type_annotations_compatible(exp, segment, depth + 1);
+    free(segment);
+    free(exp);
+    free(act);
+    return ok;
+  }
+
+  // Generic list compatibility.
+  char *exp_inner = NULL;
+  char *act_inner = NULL;
+  if (lsp_parse_generic_inner(exp, "list", &exp_inner) &&
+      lsp_parse_generic_inner(act, "list", &act_inner)) {
+    bool ok = lsp_type_annotations_compatible(exp_inner, act_inner, depth + 1);
+    free(exp_inner);
+    free(act_inner);
+    free(exp);
+    free(act);
+    return ok;
+  }
+  free(exp_inner);
+  free(act_inner);
+
+  if (strcmp(exp, "list") == 0 && strncmp(act, "list<", 5) == 0) {
+    free(exp);
+    free(act);
+    return true;
+  }
+  if (strcmp(exp, "map") == 0 &&
+      (strncmp(act, "map<", 4) == 0 || strncmp(act, "map{", 4) == 0)) {
+    free(exp);
+    free(act);
+    return true;
+  }
+
+  // Generic map compatibility.
+  exp_inner = NULL;
+  act_inner = NULL;
+  if (lsp_parse_generic_inner(exp, "map", &exp_inner) &&
+      lsp_parse_generic_inner(act, "map", &act_inner)) {
+    size_t exp_comma = 0;
+    size_t act_comma = 0;
+    bool ok = false;
+    if (lsp_find_top_level_char(exp_inner, ',', &exp_comma) &&
+        lsp_find_top_level_char(act_inner, ',', &act_comma)) {
+      char *exp_key = lsp_trim_dup(exp_inner, exp_comma);
+      char *exp_val = lsp_trim_dup(exp_inner + exp_comma + 1,
+                                   strlen(exp_inner) - exp_comma - 1);
+      char *act_key = lsp_trim_dup(act_inner, act_comma);
+      char *act_val = lsp_trim_dup(act_inner + act_comma + 1,
+                                   strlen(act_inner) - act_comma - 1);
+      if (exp_key && exp_val && act_key && act_val) {
+        ok = lsp_type_annotations_compatible(exp_key, act_key, depth + 1) &&
+             lsp_type_annotations_compatible(exp_val, act_val, depth + 1);
+      }
+      free(exp_key);
+      free(exp_val);
+      free(act_key);
+      free(act_val);
+    }
+    free(exp_inner);
+    free(act_inner);
+    free(exp);
+    free(act);
+    return ok;
+  }
+  free(exp_inner);
+  free(act_inner);
+
+  free(exp);
+  free(act);
+  return false;
+}
+
+static bool lsp_expr_matches_type(ASTNode *node, const char *expected_type,
+                                  Symbol *symbols, AST *ast, int depth) {
+  (void)symbols;
+  if (!node || !expected_type || depth > LSP_TYPE_MATCH_MAX_DEPTH) {
+    return false;
+  }
+
+  char *expected = lsp_trim_dup(expected_type, strlen(expected_type));
+  if (!expected) {
+    return false;
+  }
+
+  // Union type support.
+  int angle_depth = 0;
+  int brace_depth = 0;
+  size_t start = 0;
+  size_t len = strlen(expected);
+  bool saw_union = false;
+  for (size_t i = 0; i < len; i++) {
+    char c = expected[i];
+    if (c == '<') {
+      angle_depth++;
+      continue;
+    }
+    if (c == '>') {
+      angle_depth--;
+      continue;
+    }
+    if (c == '{') {
+      brace_depth++;
+      continue;
+    }
+    if (c == '}') {
+      brace_depth--;
+      continue;
+    }
+    if (angle_depth == 0 && brace_depth == 0 && c == 'o' && i + 1 < len &&
+        expected[i + 1] == 'r' &&
+        (i == 0 || isspace((unsigned char)expected[i - 1])) &&
+        (i + 2 >= len || isspace((unsigned char)expected[i + 2]))) {
+      saw_union = true;
+      char *segment = lsp_trim_dup(expected + start, i - start);
+      if (!segment) {
+        free(expected);
+        return false;
+      }
+      bool ok = lsp_expr_matches_type(node, segment, symbols, ast, depth + 1);
+      free(segment);
+      if (ok) {
+        free(expected);
+        return true;
+      }
+      i += 2;
+      while (i < len && isspace((unsigned char)expected[i])) {
+        i++;
+      }
+      if (i > 0) {
+        start = i;
+        i--;
+      } else {
+        start = i;
+      }
+    }
+  }
+  if (saw_union) {
+    char *segment = lsp_trim_dup(expected + start, len - start);
+    bool ok =
+        segment && lsp_expr_matches_type(node, segment, symbols, ast, depth + 1);
+    free(segment);
+    free(expected);
+    return ok;
+  }
+
+  if (node->type == AST_VAR) {
+    Symbol *sym = find_symbol(node->as.var_name);
+    if (!sym || !sym->type_name) {
+      free(expected);
+      return true; // Unknown variable type; avoid false-positive diagnostics.
+    }
+    bool ok = lsp_type_annotations_compatible(expected, sym->type_name, depth + 1);
+    free(expected);
+    return ok;
+  }
+
+  char *inner = NULL;
+  if (lsp_parse_generic_inner(expected, "list", &inner)) {
+    bool ok = false;
+    if (node->type == AST_LIST) {
+      ok = true;
+      for (size_t i = 0; i < node->as.list.element_count; i++) {
+        if (!lsp_expr_matches_type(node->as.list.elements[i], inner, symbols,
+                                   ast, depth + 1)) {
+          ok = false;
+          break;
+        }
+      }
+    } else if (node->type == AST_LIST_COMPREHENSION) {
+      ok = lsp_expr_matches_type(node->as.list_comprehension.element_expr, inner,
+                                 symbols, ast, depth + 1);
+    }
+    free(inner);
+    free(expected);
+    return ok;
+  }
+
+  if (lsp_parse_generic_inner(expected, "map", &inner)) {
+    bool ok = false;
+    if (node->type == AST_MAP) {
+      size_t comma_idx = 0;
+      if (lsp_find_top_level_char(inner, ',', &comma_idx)) {
+        char *key_type = lsp_trim_dup(inner, comma_idx);
+        char *value_type =
+            lsp_trim_dup(inner + comma_idx + 1, strlen(inner) - comma_idx - 1);
+        if (key_type && value_type) {
+          ok = true;
+          for (size_t i = 0; i < node->as.map.entry_count; i++) {
+            if (!lsp_expr_matches_type(node->as.map.keys[i], key_type, symbols,
+                                       ast, depth + 1) ||
+                !lsp_expr_matches_type(node->as.map.values[i], value_type,
+                                       symbols, ast, depth + 1)) {
+              ok = false;
+              break;
+            }
+          }
+        }
+        free(key_type);
+        free(value_type);
+      }
+    }
+    free(inner);
+    free(expected);
+    return ok;
+  }
+
+  size_t expected_len = strlen(expected);
+  if (expected_len >= 5 && strncmp(expected, "map{", 4) == 0 &&
+      expected[expected_len - 1] == '}') {
+    if (node->type != AST_MAP) {
+      free(expected);
+      return false;
+    }
+    char *fields = lsp_trim_dup(expected + 4, expected_len - 5);
+    if (!fields) {
+      free(expected);
+      return false;
+    }
+    if (fields[0] == '\0') {
+      free(fields);
+      free(expected);
+      return true;
+    }
+
+    bool ok = true;
+    size_t fields_len = strlen(fields);
+    size_t field_start = 0;
+    int inner_angle = 0;
+    int inner_brace = 0;
+    for (size_t i = 0; i <= fields_len; i++) {
+      char c = (i < fields_len) ? fields[i] : ',';
+      if (i < fields_len) {
+        if (c == '<') {
+          inner_angle++;
+          continue;
+        }
+        if (c == '>') {
+          inner_angle--;
+          continue;
+        }
+        if (c == '{') {
+          inner_brace++;
+          continue;
+        }
+        if (c == '}') {
+          inner_brace--;
+          continue;
+        }
+      }
+      if (c == ',' && inner_angle == 0 && inner_brace == 0) {
+        char *field = lsp_trim_dup(fields + field_start, i - field_start);
+        size_t colon_idx = 0;
+        if (!field || !lsp_find_top_level_char(field, ':', &colon_idx)) {
+          free(field);
+          ok = false;
+          break;
+        }
+        char *field_name = lsp_trim_dup(field, colon_idx);
+        char *field_type =
+            lsp_trim_dup(field + colon_idx + 1, strlen(field) - colon_idx - 1);
+        free(field);
+        if (!field_name || !field_type || field_name[0] == '\0' ||
+            field_type[0] == '\0') {
+          free(field_name);
+          free(field_type);
+          ok = false;
+          break;
+        }
+
+        bool found = false;
+        for (size_t m = 0; m < node->as.map.entry_count; m++) {
+          ASTNode *key = node->as.map.keys[m];
+          if (key && key->type == AST_STRING && key->as.string.value &&
+              strcmp(key->as.string.value, field_name) == 0) {
+            found = true;
+            if (!lsp_expr_matches_type(node->as.map.values[m], field_type,
+                                       symbols, ast, depth + 1)) {
+              ok = false;
+            }
+            break;
+          }
+        }
+        free(field_name);
+        free(field_type);
+        if (!found || !ok) {
+          ok = false;
+          break;
+        }
+        field_start = i + 1;
+      }
+    }
+    free(fields);
+    free(expected);
+    return ok;
+  }
+
+  ExprType inferred = infer_type_with_ast(node, symbols, ast);
+  ExprType expected_expr = expr_type_from_annotation(expected);
+  bool ok = false;
+  if (expected_expr != TYPE_UNKNOWN) {
+    ok = inferred == expected_expr;
+  }
+  free(expected);
+  return ok;
+}
+
+static char *lsp_describe_expr_type(ASTNode *node, Symbol *symbols, AST *ast) {
+  if (!node) {
+    return strdup("unknown");
+  }
+  if (node->type == AST_VAR) {
+    Symbol *sym = find_symbol(node->as.var_name);
+    if (sym && sym->type_name) {
+      return strdup(sym->type_name);
+    }
+  }
+
+  switch (node->type) {
+  case AST_NUMBER:
+    return strdup("number");
+  case AST_STRING:
+  case AST_FSTRING:
+    return strdup("string");
+  case AST_BOOL:
+    return strdup("boolean");
+  case AST_NULL:
+    return strdup("null");
+  case AST_LIST:
+  case AST_LIST_COMPREHENSION:
+    return strdup("list");
+  case AST_MAP:
+    return strdup("map");
+  case AST_RANGE:
+    return strdup("range");
+  default:
+    break;
+  }
+
+  ExprType inferred = infer_type_with_ast(node, symbols, ast);
+  switch (inferred) {
+  case TYPE_NUMBER:
+    return strdup("number");
+  case TYPE_STRING:
+    return strdup("string");
+  case TYPE_LIST:
+    return strdup("list");
+  case TYPE_MAP:
+    return strdup("map");
+  case TYPE_RANGE:
+    return strdup("range");
+  case TYPE_BOOL:
+    return strdup("boolean");
+  case TYPE_NULL:
+    return strdup("null");
+  default:
+    return strdup("unknown");
+  }
 }
 
 void check_function_calls(AST *ast, const char *text, Symbol *symbols,
@@ -1254,44 +1912,11 @@ void check_undefined_variables(AST *ast, const char *text, Symbol *symbols,
         if (found && node->as.assign.value) {
           Symbol *sym = find_symbol(node->as.assign.name);
           if (sym && sym->type_name) {
-            // Variable has an explicit type annotation - check if the new value
-            // matches
             const char *expected_type = sym->type_name;
-            const char *actual_type = NULL;
+            bool matches = lsp_expr_matches_type(node->as.assign.value,
+                                                 expected_type, symbols, ast, 0);
 
-            // Infer type from the assigned value
-            switch (node->as.assign.value->type) {
-            case AST_NUMBER:
-              actual_type = "number";
-              break;
-            case AST_STRING:
-            case AST_FSTRING:
-              actual_type = "string";
-              break;
-            case AST_BOOL:
-              actual_type = "bool";
-              break;
-            case AST_LIST:
-              actual_type = "list";
-              break;
-            case AST_NULL:
-              actual_type = "null";
-              break;
-            case AST_VAR: {
-              // For variables, try to infer from symbol table
-              Symbol *val_sym = find_symbol(node->as.assign.value->as.var_name);
-              if (val_sym && val_sym->type_name) {
-                actual_type = val_sym->type_name;
-              }
-              break;
-            }
-            default:
-              // Unknown type - skip check
-              break;
-            }
-
-            // If we have both expected and actual types, check for mismatch
-            if (actual_type && strcmp(expected_type, actual_type) != 0) {
+            if (!matches) {
               // Find the position of the problematic value (not the entire
               // assignment) Since we're processing AST nodes in order, we can
               // find all assignments of this variable and use the current
@@ -1335,11 +1960,16 @@ void check_undefined_variables(AST *ast, const char *text, Symbol *symbols,
                 value_length = strlen(node->as.assign.name);
               }
 
+              char *actual_type_name =
+                  lsp_describe_expr_type(node->as.assign.value, symbols, ast);
+              if (!actual_type_name) {
+                actual_type_name = strdup("unknown");
+              }
+
               char escaped_msg[LSP_ERROR_MSG_SIZE];
-              snprintf(
-                  escaped_msg, sizeof(escaped_msg),
-                  "Type mismatch for variable '%s': expected '%s', got '%s'",
-                  node->as.assign.name, expected_type, actual_type);
+              snprintf(escaped_msg, sizeof(escaped_msg),
+                       "Type mismatch for variable '%s': expected '%s', got '%s'",
+                       node->as.assign.name, expected_type, actual_type_name);
               char escaped_msg_final[LSP_ERROR_MSG_SIZE];
               json_escape(escaped_msg, escaped_msg_final,
                           sizeof(escaped_msg_final));
@@ -1354,6 +1984,7 @@ void check_undefined_variables(AST *ast, const char *text, Symbol *symbols,
                   *has_diagnostics ? "," : "", line - 1, col, line - 1,
                   col + value_length, escaped_msg_final);
               *has_diagnostics = true;
+              free(actual_type_name);
             }
           }
         }

--- a/src/lsp/lsp_handlers.c
+++ b/src/lsp/lsp_handlers.c
@@ -323,6 +323,8 @@ void handle_document_symbols(const char *id) {
       kind_str = "12"; // Function
     else if (sym->type == SYMBOL_PARAMETER)
       kind_str = "5"; // Property
+    else if (sym->type == SYMBOL_TYPE_ALIAS)
+      kind_str = "13"; // Type parameter-like
 
     char *escaped_name = malloc(strlen(sym->name) * 2 + 1);
     if (escaped_name) {
@@ -401,6 +403,8 @@ void handle_workspace_symbol(const char *id, const char *body) {
         kind_str = "12"; // Function
       else if (sym->type == SYMBOL_PARAMETER)
         kind_str = "5"; // Property
+      else if (sym->type == SYMBOL_TYPE_ALIAS)
+        kind_str = "13"; // Type parameter-like
 
       char *escaped_name = malloc(strlen(sym->name) * 2 + 1);
       if (escaped_name) {

--- a/src/lsp/lsp_hover.c
+++ b/src/lsp/lsp_hover.c
@@ -231,6 +231,8 @@ void handle_hover(const char *id, const char *body) {
     type_str = "function";
   else if (sym->type == SYMBOL_PARAMETER)
     type_str = "parameter";
+  else if (sym->type == SYMBOL_TYPE_ALIAS)
+    type_str = "type alias";
 
   char *escaped_name = malloc(strlen(sym->name) * 2 + 1);
   if (!escaped_name) {
@@ -296,6 +298,24 @@ void handle_hover(const char *id, const char *body) {
                "\n*Accepts %zu to %zu argument%s*",
                sym->required_param_count, sym->param_count,
                sym->param_count == 1 ? "" : "s");
+    }
+  } else if (sym->type == SYMBOL_TYPE_ALIAS) {
+    if (sym->type_name) {
+      char *escaped_type = malloc(strlen(sym->type_name) * 2 + 1);
+      if (escaped_type) {
+        json_escape(sym->type_name, escaped_type,
+                    strlen(sym->type_name) * 2 + 1);
+        snprintf(hover_text, sizeof(hover_text),
+                 "**type alias** `%s`\n\nResolves to: `%s`", escaped_name,
+                 escaped_type);
+        free(escaped_type);
+      } else {
+        snprintf(hover_text, sizeof(hover_text), "**type alias** `%s`",
+                 escaped_name);
+      }
+    } else {
+      snprintf(hover_text, sizeof(hover_text), "**type alias** `%s`",
+               escaped_name);
     }
   } else if (sym->type_name) {
     char *escaped_type = malloc(strlen(sym->type_name) * 2 + 1);

--- a/src/lsp/lsp_utils.c
+++ b/src/lsp/lsp_utils.c
@@ -734,6 +734,40 @@ Symbol *load_module_exports(const char *file_path) {
         *tail = sym;
         tail = &sym->next;
       }
+    } else if (node->type == AST_TYPE_ALIAS && node->as.type_alias.name) {
+      Symbol *sym = malloc(sizeof(Symbol));
+      if (sym) {
+        sym->name = strdup(node->as.type_alias.name);
+        sym->type = SYMBOL_TYPE_ALIAS;
+        if (source_for_pos) {
+          char pattern[LSP_PATTERN_BUFFER_SIZE];
+          int n = snprintf(pattern, sizeof(pattern), "type %s to", sym->name);
+          if (n >= 0 && (size_t)n < sizeof(pattern)) {
+            find_node_position(node, source_for_pos, pattern, &sym->line,
+                               &sym->column);
+            if (sym->line == 1 && sym->column == 0) {
+              get_node_position(node, &sym->line, &sym->column);
+            }
+          } else {
+            get_node_position(node, &sym->line, &sym->column);
+          }
+        } else {
+          get_node_position(node, &sym->line, &sym->column);
+        }
+        sym->type_name = node->as.type_alias.target_type
+                             ? strdup(node->as.type_alias.target_type)
+                             : NULL;
+        sym->is_mutable = false;
+        sym->param_count = 0;
+        sym->required_param_count = 0;
+        sym->has_variadic = false;
+        sym->param_names = NULL;
+        sym->written = false;
+        sym->read = false;
+        sym->next = NULL;
+        *tail = sym;
+        tail = &sym->next;
+      }
     }
   }
 
@@ -818,6 +852,7 @@ char *get_module_hover_info(ImportedModule *mod) {
     Symbol *sym = mod->exports;
     int func_count = 0;
     int var_count = 0;
+    int alias_count = 0;
     while (sym) {
       if (sym->type == SYMBOL_FUNCTION) {
         func_count++;
@@ -909,10 +944,49 @@ char *get_module_hover_info(ImportedModule *mod) {
             pos += (size_t)ret;
           }
         }
+      } else if (sym->type == SYMBOL_TYPE_ALIAS) {
+        alias_count++;
+        remaining = buffer_size - pos;
+        if (remaining > 0) {
+          ret = snprintf(hover_text + pos, remaining, "• `%s` (type alias",
+                         sym->name);
+          if (ret < 0)
+            ret = 0;
+          if ((size_t)ret >= remaining) {
+            pos = buffer_size - 1;
+          } else {
+            pos += (size_t)ret;
+          }
+        }
+        if (sym->type_name) {
+          remaining = buffer_size - pos;
+          if (remaining > 0) {
+            ret = snprintf(hover_text + pos, remaining, " -> `%s`",
+                           sym->type_name);
+            if (ret < 0)
+              ret = 0;
+            if ((size_t)ret >= remaining) {
+              pos = buffer_size - 1;
+            } else {
+              pos += (size_t)ret;
+            }
+          }
+        }
+        remaining = buffer_size - pos;
+        if (remaining > 0) {
+          ret = snprintf(hover_text + pos, remaining, ")\n");
+          if (ret < 0)
+            ret = 0;
+          if ((size_t)ret >= remaining) {
+            pos = buffer_size - 1;
+          } else {
+            pos += (size_t)ret;
+          }
+        }
       }
       sym = sym->next;
     }
-    if (func_count == 0 && var_count == 0) {
+    if (func_count == 0 && var_count == 0 && alias_count == 0) {
       remaining = buffer_size - pos;
       if (remaining > 0) {
         ret = snprintf(hover_text + pos, remaining, "No exports found\n");
@@ -1133,6 +1207,42 @@ void process_statements_for_symbols(ASTNode **statements, size_t count,
       if (node->as.function.block && node->as.function.block_size > 0) {
         process_statements_for_symbols(
             node->as.function.block, node->as.function.block_size, tail, head);
+      }
+      break;
+    }
+    case AST_TYPE_ALIAS: {
+      Symbol *existing = head ? *head : NULL;
+      while (existing) {
+        if (existing->name &&
+            strcmp(existing->name, node->as.type_alias.name) == 0 &&
+            existing->type == SYMBOL_TYPE_ALIAS) {
+          break;
+        }
+        existing = existing->next;
+      }
+
+      if (!existing) {
+        sym = malloc(sizeof(Symbol));
+        if (!sym)
+          break;
+        sym->name = strdup(node->as.type_alias.name);
+        sym->type = SYMBOL_TYPE_ALIAS;
+        sym->is_mutable = false;
+        sym->type_name = node->as.type_alias.target_type
+                             ? strdup(node->as.type_alias.target_type)
+                             : NULL;
+        sym->param_count = 0;
+        sym->required_param_count = 0;
+        sym->has_variadic = false;
+        sym->param_names = NULL;
+        sym->written = false;
+        sym->read = false;
+        get_node_position(node, &line, &col);
+        sym->line = line;
+        sym->column = col;
+        sym->next = NULL;
+        **tail = sym;
+        *tail = &sym->next;
       }
       break;
     }

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1757,6 +1757,13 @@ int vm_set_global(KronosVM *vm, const char *name, KronosValue *value,
                      GLOBALS_MAX);
   }
 
+  // Validate initial assignment against declared type.
+  if (type_name != NULL && !value_is_type(value, type_name)) {
+    return vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                     "Type mismatch for variable '%s': expected '%s'", name,
+                     type_name);
+  }
+
   // Allocate into temporary pointers first, check each for NULL
   char *name_copy = strdup(name);
   if (!name_copy) {
@@ -1871,6 +1878,13 @@ int vm_set_local(KronosVM *vm, CallFrame *frame, const char *name,
     return vm_errorf(vm, KRONOS_ERR_RUNTIME,
                      "Maximum number of local variables exceeded (%d allowed)",
                      LOCALS_MAX);
+  }
+
+  // Validate initial assignment against declared type.
+  if (type_name != NULL && !value_is_type(value, type_name)) {
+    return vm_errorf(vm, KRONOS_ERR_RUNTIME,
+                     "Type mismatch for local variable '%s': expected '%s'",
+                     name, type_name);
   }
 
   // Allocate into temporary pointers first, check each for NULL

--- a/tests/integration/fail/type_alias_shape_mismatch.kr
+++ b/tests/integration/fail/type_alias_shape_mismatch.kr
@@ -1,0 +1,5 @@
+# Test: Type alias with map shape mismatch
+# Expected: Error - required field type does not match alias
+
+type Point to map x: number, y: number
+let point to map x: 1, y: "wrong" as Point

--- a/tests/integration/fail/type_generic_mismatch.kr
+++ b/tests/integration/fail/type_generic_mismatch.kr
@@ -1,0 +1,5 @@
+# Test: Generic type annotation mismatch
+# Expected: Error - list element type does not match annotation
+
+let nums to list 1, 2, 3 as list<number>
+let nums to list 4, "five", 6

--- a/tests/integration/fail/type_union_mismatch.kr
+++ b/tests/integration/fail/type_union_mismatch.kr
@@ -1,0 +1,5 @@
+# Test: Union type annotation mismatch
+# Expected: Error - boolean does not match number|string
+
+let value to 10 as number or string
+let value to true

--- a/tests/integration/pass/type_system_enhancements.kr
+++ b/tests/integration/pass/type_system_enhancements.kr
@@ -1,0 +1,22 @@
+# Test: Type system enhancements (generics, unions, aliases)
+# Expected: Pass
+
+type Point to map x: number, y: number
+type Scores to list<number>
+
+let nums to list 1, 2, 3 as list<number>
+let nums to list 4, 5, 6
+
+set score_values to list 10, 20, 30 as Scores
+
+let value to 42 as number or string
+let value to "forty-two"
+
+set origin to map x: 0, y: 0 as Point
+set moved to map x: 10, y: 20, z: 30 as Point
+
+print call len with nums
+print call len with score_values
+print value
+print origin at "x"
+print moved at "y"

--- a/tests/lsp/test_lsp_features.c
+++ b/tests/lsp/test_lsp_features.c
@@ -336,6 +336,63 @@ TEST(lsp_completion_includes_pattern_matching_keywords) {
   free(response);
 }
 
+TEST(lsp_completion_includes_type_keyword) {
+  const char *code = "set value to 1\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000); // 100ms
+  char *diag = lsp_read_diagnostics_with_message(NULL, 4);
+  free(diag);
+
+  char *response = lsp_completion(g_ctx, 0, 0);
+  ASSERT_PTR_NOT_NULL(response);
+  ASSERT_TRUE(lsp_is_valid_json(response));
+  ASSERT_TRUE(lsp_response_contains(response, "\"label\":\"type\""));
+  ASSERT_TRUE(
+      lsp_response_contains(response, "Declare type alias"));
+  free(response);
+}
+
+TEST(lsp_hover_and_definition_for_type_alias) {
+  const char *code =
+      "type Point to map x: number, y: number\n"
+      "set p to map x: 1, y: 2 as Point\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000); // 100ms
+  char *diag = lsp_read_diagnostics_with_message(NULL, 6);
+  free(diag);
+
+  char *hover = lsp_hover(g_ctx, 0, 7);
+  ASSERT_PTR_NOT_NULL(hover);
+  ASSERT_TRUE(lsp_is_valid_json(hover));
+  ASSERT_TRUE(lsp_response_contains(hover, "type alias"));
+  ASSERT_TRUE(lsp_response_contains(hover, "map{x:number,y:number}"));
+  free(hover);
+
+  // Position over "Point" (not the preceding whitespace) for definition lookup.
+  char *definition = lsp_definition(g_ctx, 1, 27);
+  ASSERT_PTR_NOT_NULL(definition);
+  ASSERT_TRUE(lsp_is_valid_json(definition));
+  ASSERT_TRUE(lsp_response_contains(definition, "\"line\":0"));
+  free(definition);
+}
+
+TEST(lsp_diagnostics_generic_type_mismatch_reported) {
+  const char *code =
+      "let nums to list 1, 2 as list<number>\n"
+      "let nums to list 3, \"bad\"\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000); // 100ms
+  char *diag =
+      lsp_read_diagnostics_with_message("Type mismatch for variable 'nums'", 8);
+  ASSERT_PTR_NOT_NULL(diag);
+  ASSERT_TRUE(lsp_is_valid_json(diag));
+  ASSERT_TRUE(lsp_response_contains(diag, "expected 'list<number>'"));
+  free(diag);
+}
+
 TEST(lsp_match_statement_diagnostics_and_definition) {
   const char *code =
       "let value to 2\n"

--- a/tests/unit/test_parser.c
+++ b/tests/unit/test_parser.c
@@ -87,6 +87,63 @@ TEST(parse_typed_assignment) {
   token_array_free(tokens);
 }
 
+TEST(parse_typed_assignment_with_generic_type) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens = tokenize("set xs to list 1, 2 as list<number>", &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  AST *ast = parse(tokens, NULL);
+  ASSERT_PTR_NOT_NULL(ast);
+  ASSERT_INT_EQ(ast->count, 1);
+  ASSERT_INT_EQ(ast->statements[0]->type, AST_ASSIGN);
+  ASSERT_STR_EQ(ast->statements[0]->as.assign.type_name, "list<number>");
+
+  ast_free(ast);
+  token_array_free(tokens);
+}
+
+TEST(parse_typed_assignment_with_union_type) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens = tokenize("set value to 1 as number or string", &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  AST *ast = parse(tokens, NULL);
+  ASSERT_PTR_NOT_NULL(ast);
+  ASSERT_INT_EQ(ast->count, 1);
+  ASSERT_INT_EQ(ast->statements[0]->type, AST_ASSIGN);
+  ASSERT_STR_EQ(ast->statements[0]->as.assign.type_name, "number or string");
+
+  ast_free(ast);
+  token_array_free(tokens);
+}
+
+TEST(parse_type_alias_declaration_and_use) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens = tokenize(
+      "type Point to map x: number, y: number\n"
+      "set p to map x: 1, y: 2 as Point",
+      &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  AST *ast = parse(tokens, NULL);
+  ASSERT_PTR_NOT_NULL(ast);
+  ASSERT_INT_EQ(ast->count, 2);
+  ASSERT_INT_EQ(ast->statements[0]->type, AST_TYPE_ALIAS);
+  ASSERT_STR_EQ(ast->statements[0]->as.type_alias.name, "Point");
+  ASSERT_STR_EQ(ast->statements[0]->as.type_alias.target_type,
+                "map{x:number,y:number}");
+
+  ASSERT_INT_EQ(ast->statements[1]->type, AST_ASSIGN);
+  ASSERT_STR_EQ(ast->statements[1]->as.assign.type_name,
+                "map{x:number,y:number}");
+
+  ast_free(ast);
+  token_array_free(tokens);
+}
+
 TEST(parse_binary_operation) {
   TokenizeError *tok_err = NULL;
   TokenArray *tokens = tokenize("set result to 10 plus 20", &tok_err);

--- a/tests/unit/test_runtime.c
+++ b/tests/unit/test_runtime.c
@@ -244,6 +244,90 @@ TEST(value_is_type) {
   value_release(nil);
 }
 
+TEST(value_is_type_union) {
+  KronosValue *num = value_new_number(10);
+  KronosValue *str = value_new_string("hello", 5);
+  KronosValue *bool_val = value_new_bool(true);
+
+  ASSERT_TRUE(value_is_type(num, "number or string"));
+  ASSERT_TRUE(value_is_type(str, "number or string"));
+  ASSERT_FALSE(value_is_type(bool_val, "number or string"));
+  ASSERT_TRUE(value_is_type(bool_val, "boolean or number"));
+
+  value_release(num);
+  value_release(str);
+  value_release(bool_val);
+}
+
+TEST(value_is_type_generic_list) {
+  KronosValue *list = value_new_list(2);
+  KronosValue *n1 = value_new_number(1);
+  KronosValue *n2 = value_new_number(2);
+  ASSERT_PTR_NOT_NULL(list);
+  ASSERT_PTR_NOT_NULL(n1);
+  ASSERT_PTR_NOT_NULL(n2);
+
+  value_retain(n1);
+  list->as.list.items[list->as.list.count++] = n1;
+  value_retain(n2);
+  list->as.list.items[list->as.list.count++] = n2;
+
+  ASSERT_TRUE(value_is_type(list, "list<number>"));
+  ASSERT_TRUE(value_is_type(list, "list<number or string>"));
+  ASSERT_FALSE(value_is_type(list, "list<string>"));
+
+  value_release(list);
+  value_release(n1);
+  value_release(n2);
+}
+
+TEST(value_is_type_generic_map) {
+  KronosValue *map = value_new_map(0);
+  KronosValue *k1 = value_new_string("x", 1);
+  KronosValue *v1 = value_new_number(1);
+  KronosValue *k2 = value_new_string("y", 1);
+  KronosValue *v2 = value_new_number(2);
+  ASSERT_PTR_NOT_NULL(map);
+  ASSERT_INT_EQ(map_set(map, k1, v1), 0);
+  ASSERT_INT_EQ(map_set(map, k2, v2), 0);
+
+  ASSERT_TRUE(value_is_type(map, "map<string, number>"));
+  ASSERT_FALSE(value_is_type(map, "map<number, number>"));
+  ASSERT_TRUE(value_is_type(map, "map<string, number or string>"));
+
+  value_release(map);
+  value_release(k1);
+  value_release(v1);
+  value_release(k2);
+  value_release(v2);
+}
+
+TEST(value_is_type_map_shape) {
+  KronosValue *map = value_new_map(0);
+  KronosValue *kx = value_new_string("x", 1);
+  KronosValue *ky = value_new_string("y", 1);
+  KronosValue *kextra = value_new_string("z", 1);
+  KronosValue *vx = value_new_number(1);
+  KronosValue *vy = value_new_number(2);
+  KronosValue *vextra = value_new_number(3);
+  ASSERT_PTR_NOT_NULL(map);
+  ASSERT_INT_EQ(map_set(map, kx, vx), 0);
+  ASSERT_INT_EQ(map_set(map, ky, vy), 0);
+  ASSERT_INT_EQ(map_set(map, kextra, vextra), 0);
+
+  ASSERT_TRUE(value_is_type(map, "map{x:number,y:number}"));
+  ASSERT_FALSE(value_is_type(map, "map{x:number,y:string}"));
+  ASSERT_FALSE(value_is_type(map, "map{x:number,missing:number}"));
+
+  value_release(map);
+  value_release(kx);
+  value_release(ky);
+  value_release(kextra);
+  value_release(vx);
+  value_release(vy);
+  value_release(vextra);
+}
+
 TEST(value_new_list) {
   KronosValue *list = value_new_list(0);
   ASSERT_PTR_NOT_NULL(list);

--- a/tests/unit/test_tokenizer.c
+++ b/tests/unit/test_tokenizer.c
@@ -564,6 +564,28 @@ TEST(tokenize_assignment_statement) {
   token_array_free(tokens);
 }
 
+TEST(tokenize_generic_type_delimiters) {
+  TokenizeError *err = NULL;
+  TokenArray *tokens = tokenize("set xs to list 1 as list<number>", &err);
+
+  ASSERT_PTR_NULL(err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  bool found_langle = false;
+  bool found_rangle = false;
+  for (size_t i = 0; i < tokens->count; i++) {
+    if (tokens->tokens[i].type == TOK_LANGLE) {
+      found_langle = true;
+    } else if (tokens->tokens[i].type == TOK_RANGLE) {
+      found_rangle = true;
+    }
+  }
+
+  ASSERT_TRUE(found_langle);
+  ASSERT_TRUE(found_rangle);
+  token_array_free(tokens);
+}
+
 /**
  * @brief Test tokenization of newlines
  *

--- a/tests/unit/test_vm.c
+++ b/tests/unit/test_vm.c
@@ -753,6 +753,105 @@ TEST(vm_set_global_type_checking) {
   vm_free(vm);
 }
 
+TEST(vm_set_global_initial_type_checking) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  KronosValue *str = value_new_string("hello", 5);
+  ASSERT_PTR_NOT_NULL(str);
+
+  // Should fail immediately: initial value violates declared type.
+  int result = vm_set_global(vm, "x", str, false, "number");
+  ASSERT_NE(result, 0);
+  ASSERT_PTR_NULL(vm_get_global(vm, "x"));
+
+  value_release(str);
+  vm_free(vm);
+}
+
+TEST(vm_execute_local_initial_type_mismatch) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "function bad:\n"
+      "    set x to \"oops\" as number\n"
+      "call bad");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_NE(result, 0);
+  ASSERT_PTR_NOT_NULL(vm->last_error_message);
+  ASSERT_TRUE(strstr(vm->last_error_message,
+                     "Type mismatch for local variable 'x': expected 'number'") !=
+              NULL);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_execute_generic_list_type_annotation) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "let values to list 1, 2, 3 as list<number>\n"
+      "let values to list 4, 5, 6");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_INT_EQ(result, 0);
+
+  KronosValue *values = vm_get_global(vm, "values");
+  ASSERT_PTR_NOT_NULL(values);
+  ASSERT_INT_EQ(values->type, VAL_LIST);
+  ASSERT_EQ(values->as.list.count, 3);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_execute_union_type_annotation) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "let value to 42 as number or string\n"
+      "let value to \"forty-two\"");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_INT_EQ(result, 0);
+
+  KronosValue *value = vm_get_global(vm, "value");
+  ASSERT_PTR_NOT_NULL(value);
+  ASSERT_INT_EQ(value->type, VAL_STRING);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_execute_type_alias_map_shape) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "type Point to map x: number, y: number\n"
+      "set p to map x: 1, y: 2 as Point\n"
+      "print p");
+  ASSERT_PTR_NOT_NULL(bytecode);
+
+  int result = vm_execute(vm, bytecode);
+  ASSERT_INT_EQ(result, 0);
+
+  KronosValue *p = vm_get_global(vm, "p");
+  ASSERT_PTR_NOT_NULL(p);
+  ASSERT_INT_EQ(p->type, VAL_MAP);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
 // Stack underflow regression tests
 // These tests ensure that stack operations are properly balanced and
 // that no stack underflow errors occur during or after execution

--- a/website/content/docs/language/data-types.mdx
+++ b/website/content/docs/language/data-types.mdx
@@ -80,3 +80,14 @@ Attempting to assign a different type will result in an error:
 let age to 25 as number
 let age to "twenty"  # Error: Type mismatch
 ```
+
+Kronos also supports richer type expressions:
+
+```kronos
+let nums to list 1, 2, 3 as list<number>
+let labels to map "id": "abc" as map<string, string>
+let value to 10 as number or string
+
+type Point to map x: number, y: number
+set p to map x: 1, y: 2 as Point
+```

--- a/website/content/docs/language/variables.mdx
+++ b/website/content/docs/language/variables.mdx
@@ -186,6 +186,27 @@ let scores to list 95, 87, 92 as list
 set config to map host: "localhost", port: 8080 as map
 ```
 
+### Generic Type Annotations
+
+```kronos
+let scores to list 95, 87, 92 as list<number>
+let grades to map "alice": 95, "bob": 88 as map<string, number>
+```
+
+### Union Type Annotations
+
+```kronos
+let result to 42 as number or string
+let result to "forty-two"  # Also valid
+```
+
+### Type Aliases
+
+```kronos
+type Point to map x: number, y: number
+set origin to map x: 0, y: 0 as Point
+```
+
 ---
 
 ## Naming Rules

--- a/website/content/docs/roadmap.mdx
+++ b/website/content/docs/roadmap.mdx
@@ -320,7 +320,7 @@ set q, r to call divide_with_remainder with 10, 3
 - Named arguments: `call create_user with name: "Alice", age: 30`
 </Accordion>
 
-<Accordion title="Type System Enhancements">
+<Accordion title="Type System Enhancements ✓">
 - Generic types: `list<number>`, `map<string, number>`
 - Type aliases: `type Point to map x: number, y: number`
 - Multi-type support: `as number or string`


### PR DESCRIPTION
## Summary

Implement the 0.5.0 Type System Enhancements end to end (parser/compiler/runtime/LSP), including generic annotations, type aliases, and union types, plus full validation and docs updates.

## Changes

- Added type-expression support in parser:
  - Generic types (`list<number>`, `map<string, number>`)
  - Union types (`number or string`)
  - Type aliases (`type Point to ...`) with alias resolution
- Added tokenizer support for generic delimiters (`<`, `>`) and new AST support for type alias declarations.
- Updated compiler to handle type alias nodes as compile-time metadata (no runtime bytecode emission).
- Extended runtime type checking to support:
  - Generics (`list<T>`, `map<K,V>`)
  - Unions (`A or B`)
  - Structural map shapes (`map{x:number,y:number}`)
- Fixed VM type-safety behavior to enforce typed declarations on initial assignment for globals and locals (not only on reassignment).
- Extended LSP support for type aliases across:
  - Document/workspace symbols
  - Hover
  - Completion
  - Diagnostics
- Added/updated unit, integration, and LSP tests for all new type-system behavior.
- Fixed one LSP test-position issue (definition request now points at the symbol character rather than whitespace).

## Testing

- `./scripts/run_tests.sh` (unit + integration) passes
- `make test-lsp` passes
- Sanitizer runs pass:
  - `make test-unit` with `ASAN+UBSAN`
  - `make test-lsp` with `ASAN+UBSAN`
- Memory workflow passes via act:
  - `act push -W .github/workflows/memory-check.yml -j memory-check`
- Linux CI workflow jobs pass via act:
  - `act push -W .github/workflows/test.yml -j unit-tests --matrix os:ubuntu-latest`
  - `act push -W .github/workflows/test.yml -j integration-tests --matrix os:ubuntu-latest`
- macOS local build/tests pass:
  - `make`
  - `./scripts/run_tests.sh`
  - `make test-lsp`

- [x] All existing tests pass
- [x] New tests added (if applicable)
- [ ] Examples updated (if applicable)
- [x] Memory leak checks pass (if applicable)

## Documentation

- Updated roadmap and docs to mark/document Type System Enhancements:
  - `ROADMAP.md`
  - `README.md`
  - `website/content/docs/roadmap.mdx`
  - `website/content/docs/language/variables.mdx`
  - `website/content/docs/language/data-types.mdx`

- [x] Examples updated (if applicable)
- [x] README/docs updated (if applicable)

## Breaking Changes

None