### PR TITLE
feat: add method chaining support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -403,7 +403,8 @@ This document outlines the planned features and release schedule for Kronos.
   - **JSON:** `parse_json()`, `to_json()`
   - **Modules in scope:** `math`, `string`, `os`, `json`, `time`, `collections`, `regex`
 
-- **Method Chaining (Beta)** - Fluent API support with parser/runtime hardening
+- ✅ **Method Chaining (Beta)** - Fluent API support with parser/runtime and
+  LSP hardening (completed)
 
   ```kronos
   set result to text.uppercase().trim().split(" ")

--- a/docs/BOOTSTRAP_ANALYSIS.md
+++ b/docs/BOOTSTRAP_ANALYSIS.md
@@ -12,219 +12,341 @@ There are two useful milestones:
 
 2. **Autonomous bootstrap**
 
-   A Kronos implementation that can produce and reuse its own compiler artifacts without depending on the C host build for each iteration.
+   A Kronos implementation that can produce and reuse its own compiler artifacts
+   without depending on the C host frontend for each iteration.
 
-These are different goals. Kronos is much closer to the first than the second.
+These are different goals. With the current language surface, Kronos is now
+comfortably in range of the first milestone. It still needs an artifact path or
+native build orchestration to reach the second.
 
 ## Current State
 
-Kronos is currently in **public beta** at **v0.4.5**.
+Kronos is currently tracked as **0.5.2-beta**, with the website runtime migration
+complete.
 
-The implementation is still centered on a C toolchain:
+The implementation remains centered on a C toolchain:
 
 - Tokenizer in C
 - Parser in C
 - Compiler in C
 - Bytecode VM in C
+- Built-in runtime/library modules in C
+- LSP server in C
 - WASM build of the same runtime for the website playground
 
-Kronos already compiles source to bytecode and executes that bytecode in the VM. There is no C code generation backend in the current architecture.
+Kronos compiles source to bytecode and executes that bytecode in the VM. The
+current architecture is bytecode-first; there is still no C code generation
+backend in the repo.
 
 ## What Kronos Already Has
 
-These features are already present and are sufficient for implementing a substantial amount of compiler logic in Kronos itself:
+The available language and runtime surface is now broad enough for a substantial
+compiler implementation in Kronos itself:
 
-- ✅ Strings and string manipulation
-- ✅ Lists
-- ✅ Maps / dictionaries
-- ✅ Ranges
-- ✅ Functions
-- ✅ Control flow (`if`, `for`, `while`, `break`, `continue`)
-- ✅ Arithmetic, comparison, and logical operators
-- ✅ Modules (`import math`, `import regex`, `import module from "file.kr"`)
-- ✅ Exceptions (`try` / `catch` / `finally`)
-- ✅ File I/O (`read_file`, `write_file`, `read_lines`)
-- ✅ File/path helpers (`file_exists`, `list_files`, `join_path`, `dirname`, `basename`)
-- ✅ Regular expressions (`regex.match`, `regex.search`, `regex.findall`)
+- Strings, string indexing/slicing, f-strings, and string helpers
+- Lists, list indexing/slicing, list mutation, comprehensions, and higher-order
+  helpers (`map`, `filter`, `sort`, `reverse`, `zip`, `enumerate`, `any`, `all`,
+  `sum`)
+- Maps/dictionaries with hash-table storage, literals, indexing, mutation, and
+  deletion
+- Ranges with indexing, slicing, iteration, and length
+- Functions with parameters, return values, default parameters, variadic
+  parameters, named arguments, lambdas, and multiple return values
+- Control flow (`if`, `else if`, `else`, `for`, `while`, `break`, `continue`,
+  `match`)
+- Arithmetic, comparison, logical operators, modulo, and unary negation
+- Type annotations, generic types, type aliases, and union types
+- Modules (`import math`, other built-in modules, and `import module from
+  "file.kr"`)
+- Exceptions (`try` / `catch` / `finally`, typed raises, catch-all handling)
+- File I/O (`read_file`, `write_file`, `read_lines`)
+- File/path helpers (`file_exists`, `list_files`, `join_path`, `dirname`,
+  `basename`)
+- Regular expressions (`regex.match`, `regex.search`, `regex.findall`)
+- JSON helpers (`json.parse_json`, `json.to_json`)
+- Time and OS-adjacent helpers (`time.now`, `time.sleep`, date formatting/parsing,
+  `os.args`, `os.env`, `os.exit`)
+- Debug statements and LSP coverage for a large part of the language
 
 From a language-expressiveness standpoint, this is enough to write:
 
 - A tokenizer
 - A parser
-- AST transforms
+- AST and IR transforms
 - Semantic checks
-- A simple code generator or bytecode emitter
+- A bytecode assembler/emitter
+- A source-to-source tool or formatter
+- Compiler-driver logic that reads source files and writes generated artifacts
+
+The main hosted-compiler work is now engineering effort and specification
+discipline, not waiting for one missing collection type or syntax feature.
 
 ## What Is Still Missing
 
 ### Critical for Autonomous Bootstrap
 
-1. **Artifact generation and reuse**
+1. **Bytecode/artifact serialization and loading**
 
-   Kronos can generate bytecode internally today, but the repo does not currently expose bytecode save/load or serialization as a user-facing capability.
-
-   Why this matters:
-
-   - A self-hosted compiler needs a way to emit a reusable build artifact
-   - That artifact must be loadable later without recompiling from source through the C host
-
-2. **System / process execution**
-
-   There is no language-level `system()`, `exec()`, or similar process API in the current implementation.
+   The C compiler produces a `Bytecode` structure internally, and functions carry
+   bytecode bodies at runtime, but the repo does not expose a stable bytecode
+   file format or user-facing save/load/execute path.
 
    Why this matters:
 
-   - A Kronos compiler that emits C would need to invoke `gcc`/`clang`
-   - A toolchain written in Kronos eventually needs some way to orchestrate external build steps
+   - A self-hosted compiler needs to emit a reusable artifact.
+   - The runtime needs to load that artifact later without sending source through
+     the C tokenizer, parser, and compiler.
+   - The artifact format needs to encode instructions, constants, function
+     metadata, module references, and enough versioning to survive VM changes.
+
+2. **System/process execution**
+
+   Kronos now has `os.args`, `os.env`, and `os.exit`, but no language-level
+   `system()`, `exec()`, `spawn()`, or subprocess API.
+
+   Why this matters:
+
+   - A Kronos compiler that emits C would need to invoke `gcc`/`clang`.
+   - A toolchain written in Kronos eventually needs to run external build,
+     testing, packaging, and documentation steps.
+   - Without process execution, Kronos can still generate files, but another
+     host must orchestrate non-Kronos commands.
 
 ### Important but Not Strictly Required for a First Hosted Compiler
 
-3. **Better tooling and packaging**
+3. **A formal bytecode/IR specification**
 
-   A self-hosted compiler is easier to maintain once formatter/linter/test tooling exists in Kronos itself. These are roadmap items, not blockers for a first compiler implementation.
+   A hosted compiler can start by matching the current C compiler's bytecode, but
+   that bytecode is currently a C-internal contract. A stable spec would reduce
+   the risk of the Kronos compiler chasing implementation details.
 
-4. **Advanced language features**
+4. **Binary data or byte-oriented file APIs**
 
-   v0.5.0 is focused on lambdas, list comprehensions, pattern matching, and an enhanced type system. These will help ergonomics, but they are not required for a basic compiler.
+   The current file APIs are enough for text source, JSON, and textual assembly
+   formats. A compact bytecode artifact would be easier with byte arrays or
+   explicit binary read/write support. This is not required if the first artifact
+   format is textual.
+
+5. **More self-hosted tooling**
+
+   Formatter, linter, test runner, package tooling, and compiler fixture tooling
+   would make a self-hosted compiler maintainable, but they are not blockers for
+   the first hosted compiler.
 
 ### Explicitly Not a Blocker
 
-5. **Concurrency**
+6. **Concurrency**
 
-   Concurrency is planned for **v0.8.0**. It may help performance later, but it is not needed for bootstrap.
+   Concurrency may help build throughput later, but it is not needed for
+   bootstrap. The parser, compiler, and bytecode emitter can be single-threaded.
 
 ## Bootstrap Strategy Options
 
-### Option 1: Hosted Self-Compiler Targeting Existing Bytecode Model
+### Option 1: Hosted Self-Compiler Targeting the Existing Bytecode Model
 
-**Approach:** Write the compiler in Kronos and have it run on the current C VM/runtime.
+**Approach:** Write the compiler in Kronos and have it run on the current C
+VM/runtime.
 
-- Read `.kr` source files
-- Tokenize and parse in Kronos
-- Perform semantic analysis
-- Emit an internal representation aligned with the existing bytecode VM
-- Use the current host implementation to run and validate the compiler
+- Read `.kr` source files.
+- Tokenize and parse in Kronos.
+- Perform semantic analysis.
+- Emit an IR or textual bytecode assembly aligned with the existing VM.
+- Use the current C implementation to run and validate the compiler.
 
 **Pros:**
 
-- Matches the current architecture
-- Uses language features that already exist
-- Avoids adding a new backend before the compiler logic exists
+- Matches the current architecture.
+- Uses language features that already exist.
+- Avoids adding a native backend before compiler logic exists.
+- Creates direct pressure to specify the VM bytecode contract.
 
 **Cons:**
 
-- Still depends on the current C implementation as the host
-- Does not by itself produce a reusable standalone compiler artifact
+- Still depends on the current C implementation as the host.
+- Does not by itself produce a reusable standalone compiler artifact.
+- Needs either a bytecode assembler/load path or a textual intermediate format
+  consumed by C tooling.
 
-**Assessment:** This is the most realistic next bootstrap milestone.
+**Assessment:** This is still the best next bootstrap milestone, and it is more
+plausible now than the older analysis suggested.
 
 ### Option 2: Bytecode Serialization / Compiler Artifact Path
 
-**Approach:** Extend Kronos so compiled bytecode can be saved, loaded, and executed as a stable artifact format.
+**Approach:** Extend Kronos and the C host so compiled artifacts can be saved,
+loaded, and executed as a stable format.
 
-- Write compiler in Kronos
-- Emit bytecode or a serialized compiler artifact
-- Save artifact to disk
-- Load artifact later without recompiling from source through the C frontend
+- Specify the bytecode artifact format.
+- Add C-side save/load/execute support.
+- Let the Kronos compiler emit that format.
+- Load the emitted artifact later without recompiling source through the C
+  frontend.
 
 **Pros:**
 
-- Fits the current bytecode-first implementation
-- Reduces dependency on an added C backend
-- Moves Kronos toward genuine autonomous bootstrap
+- Fits the bytecode-first implementation.
+- Avoids a C backend as the primary route to bootstrap.
+- Provides the cleanest route from hosted compiler to autonomous bootstrap.
+- Benefits distribution and startup time independently of self-hosting.
 
 **Cons:**
 
-- Requires a stable bytecode or artifact format
-- Needs explicit serialization/loading support that does not exist yet
+- Requires a stable bytecode/versioning contract.
+- Needs serialization for constants, functions/lambdas, module metadata, and
+  possibly debug/source mapping data.
+- Requires careful compatibility handling as opcodes evolve.
 
-**Assessment:** This is the cleanest path to an actual autonomous bootstrap.
+**Assessment:** This is the preferred autonomous-bootstrap path.
 
 ### Option 3: Add a C Code Generation Backend
 
-**Approach:** Write a compiler in Kronos that emits C, then invoke a system compiler.
+**Approach:** Write a compiler in Kronos that emits C, then invoke a system
+compiler.
 
-- Read `.kr` source files
-- Parse and analyze in Kronos
-- Generate C code
-- Call `gcc` or `clang`
+- Read `.kr` source files.
+- Parse and analyze in Kronos.
+- Generate C code.
+- Call `gcc` or `clang`.
 
 **Pros:**
 
-- Leverages mature native toolchains
-- Produces conventional binaries
+- Leverages mature native toolchains.
+- Produces conventional binaries.
+- Could eventually support native distribution.
 
 **Cons:**
 
-- Does not match the current compiler architecture
-- Requires both a new C backend and system/process execution support
-- Larger scope than the bytecode-artifact path
+- Does not match the current compiler architecture.
+- Requires a new C backend, runtime ABI design, and process execution support.
+- Larger scope than the bytecode-artifact path.
+- Risks duplicating VM semantics in generated C before the language spec is
+  stable.
 
-**Assessment:** Viable, but no longer the default recommendation.
+**Assessment:** Viable later, but no longer the default bootstrap recommendation.
+
+### Option 4: Textual Bytecode Assembly as an Intermediate Step
+
+**Approach:** Introduce a documented text representation of bytecode that Kronos
+can generate using existing string and file APIs, then add a C-side assembler or
+loader for that representation.
+
+**Pros:**
+
+- Avoids needing binary file APIs immediately.
+- Easier to inspect, diff, and test while the bytecode format settles.
+- Gives the self-hosted compiler a concrete artifact target earlier.
+
+**Cons:**
+
+- Adds an intermediate format that may be temporary.
+- Still needs a C-side loader/assembler before artifacts are reusable.
+- Less compact and likely slower to load than binary bytecode.
+
+**Assessment:** A pragmatic bridge if binary bytecode serialization feels too
+large for the first artifact milestone.
 
 ## Recommended Path
 
 The most practical roadmap is:
 
-1. Build a **hosted self-compiler** in Kronos first
-2. Add **bytecode/artifact serialization**
-3. Use that artifact path to reach **autonomous bootstrap**
-4. Treat C code generation as an optional later backend, not the first bootstrap target
+1. Define the compiler boundary: AST-to-bytecode parity, textual bytecode
+   assembly, or direct bytecode artifact emission.
+2. Build a hosted tokenizer/parser in Kronos with golden tests against the C
+   frontend.
+3. Add semantic analysis and bytecode/IR emission in Kronos.
+4. Add bytecode/artifact serialization and a C-side load/execute path.
+5. Use that artifact path to make the self-hosted compiler reusable without the
+   C frontend.
+6. Treat C code generation and subprocess orchestration as optional later
+   backend/tooling work.
 
-This sequencing matches the current repo better than the older "generate C first" framing.
+This sequencing matches the current repo better than making C code generation
+the first bootstrap target.
 
 ## Milestone Estimate
 
 ### Stage 1: Hosted Self-Compiler
 
-**Status:** Plausible now on the current language/runtime surface
+**Status:** Feasible on the current language/runtime surface.
 
-Kronos already has the core language features needed to implement compiler logic. The main work is engineering effort, not waiting on one missing syntax feature.
+Kronos has the syntax, collections, file I/O, modules, exceptions, JSON, and
+higher-order features needed to implement compiler logic. The risk is now mostly
+scope, correctness, and test coverage.
 
-### Stage 2: Autonomous Bootstrap
+Suggested first milestone:
 
-**Status:** Still blocked
+- Kronos tokenizer and parser for a deliberately chosen language subset.
+- AST represented as maps/lists or a small tagged-node convention.
+- Golden tests comparing Kronos-produced tokens/AST summaries with the C
+  frontend.
+- No bytecode emission required yet.
+
+### Stage 2: Hosted Compiler That Emits VM-Compatible Artifacts
+
+**Status:** Plausible, but needs an artifact decision.
+
+The next useful target is either:
+
+- A textual bytecode assembly file, plus a C assembler/loader; or
+- A direct serialized bytecode format, plus a C loader.
+
+This stage turns the self-hosted compiler from an analysis tool into a real
+compiler.
+
+### Stage 3: Autonomous Bootstrap
+
+**Status:** Still blocked.
 
 The missing pieces are not parser features or collection types. The blockers are:
 
-- No user-facing bytecode/artifact persistence
-- No language-level process execution
+- No user-facing bytecode/artifact persistence and load path.
+- No language-level process execution for a C-emitting or native-build path.
 
-Either of these could unblock a path:
+Either of these could unblock a route:
 
-- **Bytecode/artifact persistence** for a bytecode-first bootstrap
-- **Process execution** for a C-emitting bootstrap
+- **Bytecode/artifact persistence** for a bytecode-first bootstrap.
+- **Process execution** for a C-emitting bootstrap.
+
+The bytecode-artifact route remains the better fit for the existing codebase.
 
 ## Current Implementation Size
 
-The older compiler-size estimate is no longer accurate.
-
 Current rough implementation size in the repo:
 
-- `main.c`: ~1,013 LOC
-- `linenoise.c`: ~1,353 LOC
-- `src/core/runtime.c`: ~1,774 LOC
-- `src/core/gc.c`: ~848 LOC
-- `src/frontend/tokenizer.c`: ~1,143 LOC
-- `src/frontend/parser.c`: ~5,498 LOC
-- `src/compiler/compiler.c`: ~3,844 LOC
-- `src/vm/vm.c`: ~8,104 LOC
-- `src/lsp/*.c`: ~7,515 LOC combined
-- `wasm/kronos_wasm.c`: ~336 LOC
+- `main.c`: 1,024 LOC
+- `linenoise.c`: 1,353 LOC
+- `src/core/runtime.c`: 2,119 LOC
+- `src/core/gc.c`: 882 LOC
+- `src/frontend/tokenizer.c`: 1,169 LOC
+- `src/frontend/parser.c`: 6,350 LOC
+- `src/compiler/compiler.c`: 4,301 LOC
+- `src/vm/vm.c`: 5,787 LOC
+- `src/lsp/*.c`: 12,386 LOC combined
+- `wasm/kronos_wasm.c`: 336 LOC
 
-**Measured total across those files:** ~31,551 LOC
+**Measured total across those files:** 35,707 LOC
 
-That means a self-hosted implementation effort is now large enough that bootstrap planning should focus on architecture and artifact flow, not just language feature checklisting.
+There are also over 100 passing integration programs, over 60 failing/error
+integration programs, unit tests, LSP tests, a website, and a WASM runtime path.
+The self-hosting effort should therefore be planned as an incremental compiler
+project with compatibility gates, not a one-shot rewrite.
 
 ## Conclusion
 
-**Earliest realistic bootstrap point:** A **hosted self-compiler** is likely feasible now or soon on the current `v0.4.x` language surface.
+**Hosted self-compiler:** Feasible now on the current 0.5.x language surface.
 
-**What is no longer true:** Kronos is not mainly waiting on maps, modules, file I/O, or exceptions. Those are already implemented.
+**Autonomous bootstrap:** Still blocked until Kronos can either load reusable
+compiler artifacts or orchestrate an external native toolchain.
+
+**What is no longer true:** Kronos is not waiting on maps, modules, file I/O,
+exceptions, lambdas, comprehensions, pattern matching, or enhanced type syntax.
+Those are already implemented.
 
 **Real remaining blockers for autonomous bootstrap:**
 
-1. Bytecode/artifact serialization and loading
-2. System/process execution support
+1. Stable bytecode/artifact serialization and loading.
+2. System/process execution support, if the chosen path emits C or coordinates
+   external build steps.
 
-**Recommended strategy:** Target the existing bytecode-oriented architecture first, then add artifact persistence. That is a better fit for the repo than making C code generation the primary bootstrap plan.
+**Recommended strategy:** Target the existing bytecode-oriented architecture
+first. Add a textual or binary artifact path before investing in C code
+generation as the primary bootstrap mechanism.

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@
 #define KRONOS_VERSION_MAJOR 0
 #define KRONOS_VERSION_MINOR 4
 #define KRONOS_VERSION_PATCH 0
-#define KRONOS_VERSION_STRING "0.4.5"
+#define KRONOS_VERSION_STRING "0.6.0"
 
 // Global flag for graceful shutdown on signals
 static volatile sig_atomic_t g_signal_received = 0;

--- a/src/frontend/parser.c
+++ b/src/frontend/parser.c
@@ -561,6 +561,7 @@ static bool call_parse_arguments(Parser *p, ASTNode ***args, char ***arg_names,
                                  size_t *arg_count, size_t *arg_capacity);
 static void call_cleanup_arguments(ASTNode **args, char **arg_names,
                                    size_t arg_count);
+static ASTNode *parse_method_call(Parser *p, ASTNode *receiver);
 static ASTNode *parse_primary(Parser *p);
 static ASTNode *parse_fstring(Parser *p);
 
@@ -1294,6 +1295,29 @@ static ASTNode *parse_list_literal(Parser *p) {
   ast_node_set_position(node, list_tok);
   node->as.list.elements = elements;
   node->as.list.element_count = element_count;
+
+  // Unbracketed list literals have no closing delimiter, so a postfix chain
+  // after the final element is initially parsed as part of that element.
+  // Kronos defines that form as a method on the completed list; a bracketed
+  // list can be used when a chained expression is intended as its last item.
+  if (element_count > 0) {
+    ASTNode *chain = elements[element_count - 1];
+    if (chain && chain->type == AST_CALL && chain->as.call.is_method) {
+      ASTNode *innermost = chain;
+      while (innermost->as.call.arg_count > 0 &&
+             innermost->as.call.args[0] &&
+             innermost->as.call.args[0]->type == AST_CALL &&
+             innermost->as.call.args[0]->as.call.is_method) {
+        innermost = innermost->as.call.args[0];
+      }
+      if (innermost->as.call.arg_count > 0 &&
+          innermost->as.call.args[0]) {
+        elements[element_count - 1] = innermost->as.call.args[0];
+        innermost->as.call.args[0] = node;
+        return chain;
+      }
+    }
+  }
   return node;
 }
 
@@ -1878,14 +1902,36 @@ static ASTNode *parse_primary(Parser *p) {
     return NULL;
   }
 
-  // Handle postfix operations: at, from ... to
+  // Handle postfix operations: method calls, indexing, and slicing.
   while (true) {
     Token *tok = peek(p, 0);
     if (!tok) {
       break;
     }
 
-    if (tok->type == TOK_AT) {
+    // A chain may continue on an indented following line:
+    //   value
+    //       .trim()
+    if (tok->type == TOK_NEWLINE) {
+      size_t offset = 1;
+      Token *next = peek(p, offset);
+      if (next && next->type == TOK_INDENT) {
+        next = peek(p, ++offset);
+      }
+      if (next && next->type == TOK_DOT) {
+        while (offset-- > 0) {
+          consume_any(p);
+        }
+        tok = peek(p, 0);
+      }
+    }
+
+    if (tok && tok->type == TOK_DOT) {
+      expr = parse_method_call(p, expr);
+      if (!expr) {
+        return NULL;
+      }
+    } else if (tok->type == TOK_AT) {
       // Indexing: expr at index
       consume_any(p); // consume 'at'
       ASTNode *index = parse_expression(p);
@@ -1955,6 +2001,115 @@ static ASTNode *parse_primary(Parser *p) {
   }
 
   return expr;
+}
+
+/** Parse `.name(arg, ...)`, desugaring it to `call name with receiver, ...`. */
+static ASTNode *parse_method_call(Parser *p, ASTNode *receiver) {
+  Token *dot = consume(p, TOK_DOT);
+  if (!dot) {
+    ast_node_free(receiver);
+    return NULL;
+  }
+
+  Token *name = peek(p, 0);
+  // `map` is a keyword in literal position but also a collection method.
+  if (!name || (name->type != TOK_NAME && name->type != TOK_MAP &&
+                name->type != TOK_MATCH)) {
+    parser_set_error(p, "Expected method name after '.'");
+    ast_node_free(receiver);
+    return NULL;
+  }
+  consume_any(p);
+
+  if (!consume(p, TOK_LPAREN)) {
+    ast_node_free(receiver);
+    return NULL;
+  }
+
+  size_t capacity = INITIAL_ARRAY_CAPACITY;
+  size_t count = 1;
+  ASTNode **args = malloc(sizeof(ASTNode *) * capacity);
+  char **arg_names = calloc(capacity, sizeof(char *));
+  if (!args || !arg_names) {
+    free(args);
+    free(arg_names);
+    ast_node_free(receiver);
+    parser_set_error(p, "Failed to allocate method call arguments");
+    return NULL;
+  }
+  args[0] = receiver;
+
+  if (!peek(p, 0) || peek(p, 0)->type != TOK_RPAREN) {
+    while (true) {
+      ASTNode *arg = parse_expression(p);
+      if (!arg) {
+        call_cleanup_arguments(args, arg_names, count);
+        return NULL;
+      }
+      if (count >= capacity) {
+        if (capacity > SIZE_MAX / 2 ||
+            capacity * 2 > SIZE_MAX / sizeof(ASTNode *)) {
+          ast_node_free(arg);
+          call_cleanup_arguments(args, arg_names, count);
+          parser_set_error(p, "Method call has too many arguments");
+          return NULL;
+        }
+        size_t new_capacity = capacity * 2;
+        ASTNode **new_args = realloc(args, sizeof(ASTNode *) * new_capacity);
+        if (!new_args) {
+          ast_node_free(arg);
+          call_cleanup_arguments(args, arg_names, count);
+          parser_set_error(p, "Failed to grow method call arguments");
+          return NULL;
+        }
+        args = new_args;
+        char **new_names = realloc(arg_names, sizeof(char *) * new_capacity);
+        if (!new_names) {
+          ast_node_free(arg);
+          call_cleanup_arguments(args, arg_names, count);
+          parser_set_error(p, "Failed to grow method call argument names");
+          return NULL;
+        }
+        arg_names = new_names;
+        memset(arg_names + capacity, 0,
+               sizeof(char *) * (new_capacity - capacity));
+        capacity = new_capacity;
+      }
+      args[count++] = arg;
+
+      if (!peek(p, 0) || peek(p, 0)->type != TOK_COMMA) {
+        break;
+      }
+      consume_any(p);
+      if (peek(p, 0) && peek(p, 0)->type == TOK_RPAREN) {
+        break; // Allow a trailing comma.
+      }
+    }
+  }
+
+  if (!consume(p, TOK_RPAREN)) {
+    call_cleanup_arguments(args, arg_names, count);
+    return NULL;
+  }
+
+  ASTNode *node = ast_node_new_checked(AST_CALL);
+  if (!node) {
+    call_cleanup_arguments(args, arg_names, count);
+    return NULL;
+  }
+  ast_node_set_position(node, dot);
+  node->indent = -1;
+  node->as.call.name = strdup(name->text);
+  if (!node->as.call.name) {
+    call_cleanup_arguments(args, arg_names, count);
+    free(node);
+    return NULL;
+  }
+  node->as.call.args = args;
+  node->as.call.arg_names = arg_names;
+  node->as.call.arg_count = count;
+  node->as.call.is_method = true;
+  return node;
 }
 
 /**
@@ -4835,11 +4990,46 @@ static ASTNode *parse_call(Parser *p, int indent) {
   }
 
   Token *name = peek(p, 0);
-  if (!name || (name->type != TOK_NAME && name->type != TOK_MAP)) {
+  if (!name || (name->type != TOK_NAME && name->type != TOK_MAP &&
+                name->type != TOK_MATCH)) {
     parser_set_error(p, "Expected function name after 'call'");
     return NULL;
   }
   consume_any(p);
+
+  // Preserve legacy qualified calls (`call math.sqrt with 9`) now that dots
+  // are tokenized separately for postfix method syntax.
+  size_t qualified_len = strlen(name->text);
+  char *qualified_name = strdup(name->text);
+  if (!qualified_name) {
+    return NULL;
+  }
+  while (peek(p, 0) && peek(p, 0)->type == TOK_DOT) {
+    consume_any(p);
+    Token *part = peek(p, 0);
+    if (!part || (part->type != TOK_NAME && part->type != TOK_MAP &&
+                  part->type != TOK_MATCH)) {
+      free(qualified_name);
+      parser_set_error(p, "Expected function name after '.'");
+      return NULL;
+    }
+    consume_any(p);
+    size_t part_len = strlen(part->text);
+    if (qualified_len > SIZE_MAX - part_len - 2) {
+      free(qualified_name);
+      parser_set_error(p, "Qualified function name is too long");
+      return NULL;
+    }
+    char *grown = realloc(qualified_name, qualified_len + part_len + 2);
+    if (!grown) {
+      free(qualified_name);
+      return NULL;
+    }
+    qualified_name = grown;
+    qualified_name[qualified_len++] = '.';
+    memcpy(qualified_name + qualified_len, part->text, part_len + 1);
+    qualified_len += part_len;
+  }
 
   // Parse arguments (including named arguments)
   size_t arg_capacity = 0;
@@ -4847,6 +5037,7 @@ static ASTNode *parse_call(Parser *p, int indent) {
   ASTNode **args = NULL;
   char **arg_names = NULL;
   if (!call_parse_arguments(p, &args, &arg_names, &arg_count, &arg_capacity)) {
+    free(qualified_name);
     return NULL;
   }
 
@@ -4854,6 +5045,7 @@ static ASTNode *parse_call(Parser *p, int indent) {
   if (indent >= 0) {
     if (!consume(p, TOK_NEWLINE)) {
       call_cleanup_arguments(args, arg_names, arg_count);
+      free(qualified_name);
       return NULL;
     }
   }
@@ -4861,20 +5053,16 @@ static ASTNode *parse_call(Parser *p, int indent) {
   ASTNode *node = ast_node_new_checked(AST_CALL);
   if (!node) {
     call_cleanup_arguments(args, arg_names, arg_count);
+    free(qualified_name);
     return NULL;
   }
   ast_node_set_position(node, start_tok);
   node->indent = indent;
-  node->as.call.name = strdup(name->text);
-  if (!node->as.call.name) {
-    // Free args and arg_names
-    call_cleanup_arguments(args, arg_names, arg_count);
-    free(node);
-    return NULL;
-  }
+  node->as.call.name = qualified_name;
   node->as.call.args = args;
   node->as.call.arg_names = arg_names;
   node->as.call.arg_count = arg_count;
+  node->as.call.is_method = false;
 
   return node;
 }

--- a/src/frontend/parser.h
+++ b/src/frontend/parser.h
@@ -206,6 +206,7 @@ struct ASTNode {
       ASTNode **args;
       char **arg_names;    // Parallel array: NULL for positional, name for named args
       size_t arg_count;
+      bool is_method;      // Receiver was supplied with postfix dot syntax
     } call;
 
     // Return statement: return expr [, expr2, expr3, ...]

--- a/src/frontend/tokenizer.c
+++ b/src/frontend/tokenizer.c
@@ -130,7 +130,6 @@ static bool can_start_identifier(const char *line, size_t col, size_t len) {
  * Identifiers can continue with:
  * - ASCII letters and digits (a-z, A-Z, 0-9)
  * - Underscore (_)
- * - Dot (.) for module.function syntax
  * - Valid UTF-8 sequences (Unicode letters, digits, etc.)
  *
  * @param line The line buffer
@@ -144,8 +143,9 @@ static bool can_continue_identifier(const char *line, size_t col, size_t len) {
 
   unsigned char byte = (unsigned char)line[col];
 
-  // ASCII alphanumeric, underscore, and dot
-  if (isalnum(byte) || byte == '_' || byte == '.')
+  // ASCII alphanumeric and underscore. Dots are separate tokens so the parser
+  // can distinguish qualified function names from postfix method calls.
+  if (isalnum(byte) || byte == '_')
     return true;
 
   // Check for valid UTF-8 multi-byte sequence
@@ -181,8 +181,9 @@ static const char *token_type_names[] = {
     "TIMES",
     "DIVIDED", "BY",       "MOD",      "DELETE",   "TRY",      "CATCH",
     "FINALLY", "RAISE",    "MATCH",    "CASE",     "DEFAULT",  "NAME",
-    "COLON",   "COMMA",    "ELLIPSIS", "LPAREN",   "RPAREN",   "LBRACKET",
-    "RBRACKET", "LANGLE",  "RANGLE",   "NEWLINE", "INDENT",   "EOF"};
+    "COLON",    "COMMA",    "ELLIPSIS", "DOT",     "LPAREN", "RPAREN",
+    "LBRACKET", "RBRACKET", "LANGLE",   "RANGLE",  "NEWLINE", "INDENT",
+    "EOF"};
 
 // Compile-time check to ensure array matches enum count
 // This will cause a compilation error if they don't match
@@ -199,6 +200,7 @@ static void tokenizer_report_error(TokenizeError **out_err, const char *message,
 static const char TOKEN_TEXT_COLON[] = ":";
 static const char TOKEN_TEXT_COMMA[] = ",";
 static const char TOKEN_TEXT_ELLIPSIS[] = "...";
+static const char TOKEN_TEXT_DOT[] = ".";
 static const char TOKEN_TEXT_EQUALS[] = "=";
 static const char TOKEN_TEXT_MINUS[] = "minus";
 static const char TOKEN_TEXT_LPAREN[] = "(";
@@ -222,7 +224,8 @@ static bool is_static_token_text(const char *text) {
   return text == TOKEN_TEXT_COLON || text == TOKEN_TEXT_COMMA ||
          text == TOKEN_TEXT_ELLIPSIS || text == TOKEN_TEXT_EQUALS ||
          text == TOKEN_TEXT_MINUS || text == TOKEN_TEXT_NEWLINE ||
-         text == TOKEN_TEXT_LPAREN || text == TOKEN_TEXT_RPAREN ||
+         text == TOKEN_TEXT_DOT || text == TOKEN_TEXT_LPAREN ||
+         text == TOKEN_TEXT_RPAREN ||
          text == TOKEN_TEXT_LBRACKET || text == TOKEN_TEXT_RBRACKET ||
          text == TOKEN_TEXT_LANGLE || text == TOKEN_TEXT_RANGLE;
 }
@@ -667,8 +670,8 @@ static bool tokenize_line(TokenArray *arr, const char *line, int indent,
     }
 
     // Tokenize identifiers and keywords
-    // Identifiers can contain letters, digits, underscores, and dots
-    // (dots are allowed for module.function syntax like math.sqrt)
+    // Identifiers can contain letters, digits, and underscores. Dots are
+    // emitted separately for qualified names and method chaining.
     // Supports UTF-8 Unicode characters in identifiers
     if (can_start_identifier(line, col, len)) {
       size_t start = col;
@@ -751,6 +754,16 @@ static bool tokenize_line(TokenArray *arr, const char *line, int indent,
         return false;
       }
       col += 3;
+      continue;
+    }
+
+    if (line[col] == '.') {
+      size_t token_col = indent + col + 1;
+      Token tok = {TOK_DOT, TOKEN_TEXT_DOT, 1, 0, line_number, token_col};
+      if (!token_array_add(arr, tok, out_err, line_number, token_col)) {
+        return false;
+      }
+      col++;
       continue;
     }
 

--- a/src/frontend/tokenizer.h
+++ b/src/frontend/tokenizer.h
@@ -67,6 +67,7 @@ typedef enum {
   TOK_COLON,
   TOK_COMMA,
   TOK_ELLIPSIS,  // ... for variadic parameters
+  TOK_DOT,       // . for postfix method calls
   TOK_LPAREN,
   TOK_RPAREN,
   TOK_LBRACKET,

--- a/src/lsp/lsp_diagnostics.c
+++ b/src/lsp/lsp_diagnostics.c
@@ -2426,6 +2426,64 @@ static void check_expression_recursive(ASTNode *node, const char *text,
 
   // Check function calls recursively
   if (node->type == AST_CALL) {
+    if (node->as.call.is_method) {
+      const char *name = node->as.call.name;
+      int expected = get_builtin_arg_count(name);
+      const char *message = NULL;
+      char message_buffer[LSP_ERROR_MSG_SIZE];
+
+      if (expected >= 0 && node->as.call.arg_count != (size_t)expected) {
+        size_t explicit_expected = expected > 0 ? (size_t)expected - 1 : 0;
+        size_t explicit_actual =
+            node->as.call.arg_count > 0 ? node->as.call.arg_count - 1 : 0;
+        snprintf(message_buffer, sizeof(message_buffer),
+                 "Method '%s' expects %zu argument%s, got %zu", name,
+                 explicit_expected, explicit_expected == 1 ? "" : "s",
+                 explicit_actual);
+        message = message_buffer;
+      } else if (node->as.call.arg_count > 0) {
+        ExprType receiver_type =
+            infer_type_with_ast(node->as.call.args[0], symbols, ast);
+        bool requires_list =
+            strcmp(name, "reverse") == 0 || strcmp(name, "sort") == 0 ||
+            strcmp(name, "filter") == 0 || strcmp(name, "map") == 0;
+        bool requires_string =
+            strcmp(name, "uppercase") == 0 || strcmp(name, "lowercase") == 0 ||
+            strcmp(name, "trim") == 0 || strcmp(name, "split") == 0 ||
+            strcmp(name, "contains") == 0 ||
+            strcmp(name, "starts_with") == 0 ||
+            strcmp(name, "ends_with") == 0 || strcmp(name, "replace") == 0;
+
+        if (requires_list && receiver_type != TYPE_LIST &&
+            receiver_type != TYPE_UNKNOWN) {
+          snprintf(message_buffer, sizeof(message_buffer),
+                   "Function '%s' requires a list argument", name);
+          message = message_buffer;
+        } else if (requires_string && receiver_type != TYPE_STRING &&
+                   receiver_type != TYPE_UNKNOWN) {
+          snprintf(message_buffer, sizeof(message_buffer),
+                   "Function '%s' requires a string argument", name);
+          message = message_buffer;
+        }
+      }
+
+      if (message) {
+        char escaped[LSP_ERROR_MSG_SIZE];
+        json_escape(message, escaped, sizeof(escaped));
+        size_t line = node->line > 0 ? node->line - 1 : 0;
+        size_t col = node->column > 0 ? node->column - 1 : 0;
+        size_t needed = strlen(escaped) + strlen(name) + 200;
+        SAFE_DIAGNOSTICS_WRITE(
+            diagnostics, capacity, pos, remaining, needed,
+            "%s{\"range\":{\"start\":{\"line\":%zu,\"character\":%zu},"
+            "\"end\":{\"line\":%zu,\"character\":%zu}},"
+            "\"severity\":1,\"message\":\"%s\"}",
+            *has_diagnostics ? "," : "", line, col, line,
+            col + strlen(name) + 1, escaped);
+        *has_diagnostics = true;
+      }
+    }
+
     for (size_t i = 0; i < node->as.call.arg_count; i++) {
       check_expression_recursive(node->as.call.args[i], text, symbols, ast,
                                  diagnostics, pos, remaining, has_diagnostics,

--- a/src/lsp/lsp_handlers.c
+++ b/src/lsp/lsp_handlers.c
@@ -70,7 +70,7 @@ void handle_initialize(const char *id) {
       "\"definitionProvider\":true,"
       "\"hoverProvider\":true,"
       "\"documentSymbolProvider\":true,"
-      "\"signatureHelpProvider\":{\"triggerCharacters\":[\",\",\" \"],\"retriggerCharacters\":[\",\"]},"
+      "\"signatureHelpProvider\":{\"triggerCharacters\":[\"(\",\",\",\" \"],\"retriggerCharacters\":[\",\"]},"
       "\"inlayHintProvider\":true,"
       "\"callHierarchyProvider\":true,"
       "\"foldingRangeProvider\":true,"
@@ -1159,6 +1159,119 @@ static bool parse_call_context(const char *line, size_t line_len, size_t cursor_
   return true;
 }
 
+static bool parse_method_context(const char *line, size_t line_len,
+                                 size_t cursor_col, char *func_name,
+                                 size_t func_name_size, size_t *active_param) {
+  if (!line || !func_name || func_name_size == 0 || !active_param) {
+    return false;
+  }
+
+  size_t limit = cursor_col < line_len ? cursor_col : line_len;
+  size_t best_args_start = SIZE_MAX;
+  size_t best_name_start = 0;
+  size_t best_name_len = 0;
+  bool in_string = false;
+  char quote = '\0';
+
+  for (size_t i = 0; i < limit; i++) {
+    char c = line[i];
+    if (in_string) {
+      if (c == quote && (i == 0 || line[i - 1] != '\\')) {
+        in_string = false;
+      }
+      continue;
+    }
+    if (c == '"' || c == '\'') {
+      in_string = true;
+      quote = c;
+      continue;
+    }
+    if (c != '.') {
+      continue;
+    }
+
+    size_t name_start = i + 1;
+    if (name_start >= limit || !is_identifier_start_char(line[name_start])) {
+      continue;
+    }
+    size_t j = name_start + 1;
+    while (j < limit && is_identifier_char(line[j])) {
+      j++;
+    }
+    while (j < limit && isspace((unsigned char)line[j])) {
+      j++;
+    }
+    if (j >= limit || line[j] != '(') {
+      continue;
+    }
+
+    // Only retain an invocation whose opening parenthesis is still active at
+    // the cursor. This also selects the innermost call in a chain.
+    int depth = 1;
+    bool nested_string = false;
+    char nested_quote = '\0';
+    for (size_t k = j + 1; k < limit; k++) {
+      char nested = line[k];
+      if (nested_string) {
+        if (nested == nested_quote && line[k - 1] != '\\') {
+          nested_string = false;
+        }
+      } else if (nested == '"' || nested == '\'') {
+        nested_string = true;
+        nested_quote = nested;
+      } else if (nested == '(') {
+        depth++;
+      } else if (nested == ')') {
+        depth--;
+      }
+    }
+    if (depth > 0) {
+      best_args_start = j + 1;
+      best_name_start = name_start;
+      best_name_len = j - name_start;
+    }
+  }
+
+  if (best_args_start == SIZE_MAX || best_name_len == 0) {
+    return false;
+  }
+  size_t copy_len =
+      best_name_len < func_name_size - 1 ? best_name_len : func_name_size - 1;
+  memcpy(func_name, line + best_name_start, copy_len);
+  func_name[copy_len] = '\0';
+
+  size_t commas = 0;
+  int depth = 0;
+  int bracket_depth = 0;
+  in_string = false;
+  quote = '\0';
+  for (size_t i = best_args_start; i < limit; i++) {
+    char c = line[i];
+    if (in_string) {
+      if (c == quote && line[i - 1] != '\\') {
+        in_string = false;
+      }
+      continue;
+    }
+    if (c == '"' || c == '\'') {
+      in_string = true;
+      quote = c;
+    } else if (c == '(') {
+      depth++;
+    } else if (c == ')' && depth > 0) {
+      depth--;
+    } else if (c == '[') {
+      bracket_depth++;
+    } else if (c == ']' && bracket_depth > 0) {
+      bracket_depth--;
+    } else if (c == ',' && depth == 0 && bracket_depth == 0) {
+      commas++;
+    }
+  }
+  *active_param = commas;
+  return true;
+}
+
 static size_t split_arguments(const char *line, size_t line_len, size_t args_start,
                               ArgSegment *segments, size_t max_segments) {
   if (!line || args_start >= line_len || !segments || max_segments == 0) {
@@ -1542,10 +1655,16 @@ void handle_signature_help(const char *id, const char *body) {
 
   char function_name[128];
   size_t active_param = 0;
+  bool method_context = false;
   if (!parse_call_context(line_start, line_len, character, function_name,
                           sizeof(function_name), &active_param)) {
-    send_response(id, "null");
-    return;
+    method_context =
+        parse_method_context(line_start, line_len, character, function_name,
+                             sizeof(function_name), &active_param);
+    if (!method_context) {
+      send_response(id, "null");
+      return;
+    }
   }
 
   Symbol *function_sym = find_function_symbol(strip_module_prefix(function_name));
@@ -1574,8 +1693,11 @@ void handle_signature_help(const char *id, const char *body) {
     size_t pos = 0;
     pos += (size_t)snprintf(label + pos, sizeof(label) - pos, "%s(",
                             function_sym->name);
-    for (size_t i = 0; i < function_sym->param_count && pos < sizeof(label); i++) {
-      if (i > 0) {
+    size_t first_param =
+        method_context && function_sym->param_count > 0 ? 1 : 0;
+    for (size_t i = first_param;
+         i < function_sym->param_count && pos < sizeof(label); i++) {
+      if (i > first_param) {
         pos += (size_t)snprintf(label + pos, sizeof(label) - pos, ", ");
       }
       const char *pname =
@@ -1603,7 +1725,7 @@ void handle_signature_help(const char *id, const char *body) {
                         "\"parameters\":[");
     }
 
-    for (size_t i = 0; ok && i < function_sym->param_count; i++) {
+    for (size_t i = first_param; ok && i < function_sym->param_count; i++) {
       const char *pname =
           function_sym->param_names && function_sym->param_names[i]
               ? function_sym->param_names[i]
@@ -1611,13 +1733,15 @@ void handle_signature_help(const char *id, const char *body) {
       char escaped_param[256];
       json_escape(pname, escaped_param, sizeof(escaped_param));
       ok = append_jsonf(&json, &capacity, &len, "%s{\"label\":\"%s\"}",
-                        i == 0 ? "" : ",", escaped_param);
+                        i == first_param ? "" : ",", escaped_param);
     }
   } else if (builtin) {
     char label[512];
     size_t pos = (size_t)snprintf(label, sizeof(label), "%s(", function_name);
-    for (size_t i = 0; i < builtin->param_count && pos < sizeof(label); i++) {
-      if (i > 0) {
+    size_t first_param = method_context && builtin->param_count > 0 ? 1 : 0;
+    for (size_t i = first_param;
+         i < builtin->param_count && pos < sizeof(label); i++) {
+      if (i > first_param) {
         pos += (size_t)snprintf(label + pos, sizeof(label) - pos, ", ");
       }
       if (builtin->variadic && i == builtin->param_count - 1) {
@@ -1639,17 +1763,20 @@ void handle_signature_help(const char *id, const char *body) {
                       "%s\",\"documentation\":\"%s\",\"parameters\":[",
                       escaped_label, escaped_doc);
 
-    for (size_t i = 0; ok && i < builtin->param_count; i++) {
+    for (size_t i = first_param; ok && i < builtin->param_count; i++) {
       char escaped_param[256];
       json_escape(builtin->params[i], escaped_param, sizeof(escaped_param));
       ok = append_jsonf(&json, &capacity, &len, "%s{\"label\":\"%s\"}",
-                        i == 0 ? "" : ",", escaped_param);
+                        i == first_param ? "" : ",", escaped_param);
     }
   } else {
     int builtin_count = get_builtin_arg_count(function_name);
     size_t generic_count = builtin_count < 0 ? 1 : (size_t)builtin_count;
     if (builtin_count == -2) {
       generic_count = 1;
+    }
+    if (method_context && generic_count > 0) {
+      generic_count--;
     }
 
     char label[256];
@@ -1686,9 +1813,15 @@ void handle_signature_help(const char *id, const char *body) {
   bool variadic = false;
   if (function_sym) {
     param_count = function_sym->param_count;
+    if (method_context && param_count > 0) {
+      param_count--;
+    }
     variadic = function_sym->has_variadic;
   } else if (builtin) {
     param_count = builtin->param_count;
+    if (method_context && param_count > 0) {
+      param_count--;
+    }
     variadic = builtin->variadic;
   } else {
     int builtin_count = get_builtin_arg_count(function_name);
@@ -1697,6 +1830,9 @@ void handle_signature_help(const char *id, const char *body) {
       variadic = true;
     } else if (builtin_count > 0) {
       param_count = (size_t)builtin_count;
+    }
+    if (method_context && param_count > 0) {
+      param_count--;
     }
   }
 

--- a/src/lsp/lsp_hover.c
+++ b/src/lsp/lsp_hover.c
@@ -15,6 +15,31 @@ extern DocumentState *g_doc;
 #define LSP_HOVER_MAX_MARKDOWN_SIZE (64 * 1024)
 #define LSP_HOVER_MAX_JSON_SIZE (128 * 1024)
 
+static const char *method_description(const char *name) {
+  static const struct {
+    const char *name;
+    const char *description;
+  } methods[] = {
+      {"uppercase", "Convert the receiver string to uppercase."},
+      {"lowercase", "Convert the receiver string to lowercase."},
+      {"trim", "Remove leading and trailing whitespace from the receiver."},
+      {"split", "Split the receiver string using a delimiter."},
+      {"capitalize", "Uppercase the first character of the receiver string."},
+      {"title", "Capitalize each word in the receiver string."},
+      {"filter", "Keep receiver-list items accepted by a callback."},
+      {"map", "Transform each receiver-list item with a callback."},
+      {"reverse", "Reverse the receiver list."},
+      {"sort", "Sort the receiver list."},
+      {"len", "Return the length of the receiver."},
+  };
+  for (size_t i = 0; i < sizeof(methods) / sizeof(methods[0]); i++) {
+    if (strcmp(methods[i].name, name) == 0) {
+      return methods[i].description;
+    }
+  }
+  return NULL;
+}
+
 static bool hover_appendf(char **buffer, size_t *length, size_t *capacity,
                           size_t max_length, const char *fmt, ...) {
   if (!buffer || !length || !capacity || !fmt) {
@@ -180,6 +205,22 @@ void handle_hover(const char *id, const char *body) {
         free(module_name);
         free(word);
         send_response(id, "null"); // Could enhance this later
+        return;
+      }
+
+      const char *method_doc = method_description(func_name);
+      if (method_doc) {
+        char hover_text[512];
+        snprintf(hover_text, sizeof(hover_text),
+                 "**method** %s(...)\n\n%s\n\n"
+                 "The expression before the dot is passed as the first argument.",
+                 func_name, method_doc);
+        bool sent = send_markdown_hover_response(id, hover_text);
+        free(module_name);
+        free(word);
+        if (!sent) {
+          send_response(id, "null");
+        }
         return;
       }
 

--- a/tests/integration/fail/method_chaining_wrong_receiver.kr
+++ b/tests/integration/fail/method_chaining_wrong_receiver.kr
@@ -1,0 +1,2 @@
+# Method syntax must retain the built-in's receiver type validation.
+set invalid to "not a list".map(function with x: return x)

--- a/tests/integration/pass/method_chaining.kr
+++ b/tests/integration/pass/method_chaining.kr
@@ -1,0 +1,15 @@
+# Method chaining across strings, lists, callbacks, literals, and line breaks.
+set text to "  alpha beta gamma  "
+set words to text.uppercase().trim().split(" ")
+print words
+
+set processed to [1, 2, 3, 4]
+    .filter(function with x: return x is greater than 2)
+    .map(function with x: return x times 10)
+print processed
+
+set literal_result to ("  kronos  ").trim().capitalize()
+print literal_result
+
+set roadmap_form to list 1, 2, 3, 4.filter(function with x: return x is greater than 2).map(function with x: return x times 2)
+print roadmap_form

--- a/tests/lsp/test_lsp_features.c
+++ b/tests/lsp/test_lsp_features.c
@@ -660,6 +660,42 @@ TEST(lsp_completion_includes_filter_and_map_utilities) {
   free(response);
 }
 
+TEST(lsp_method_chaining_completion_signature_hover_and_diagnostics) {
+  const char *code = "set text to \"hello\"\n"
+                     "set parts to text.split(\",\")\n"
+                     "set bad to \"not a list\".map(function with x: return x)\n";
+  ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));
+
+  usleep(100000);
+  char *diag =
+      lsp_read_diagnostics_with_message("requires a list argument", 6);
+  ASSERT_PTR_NOT_NULL(diag);
+  ASSERT_TRUE(lsp_is_valid_json(diag));
+  ASSERT_TRUE(lsp_response_contains(
+      diag, "Function 'map' requires a list argument"));
+  free(diag);
+
+  char *completion = lsp_completion(g_ctx, 1, 18);
+  ASSERT_PTR_NOT_NULL(completion);
+  ASSERT_TRUE(lsp_is_valid_json(completion));
+  ASSERT_TRUE(lsp_response_contains(completion, "\"label\":\"split\""));
+  ASSERT_TRUE(lsp_response_contains(completion, "\"label\":\"filter\""));
+  free(completion);
+
+  char *signature = lsp_signature_help(g_ctx, 1, 27);
+  ASSERT_PTR_NOT_NULL(signature);
+  ASSERT_TRUE(lsp_is_valid_json(signature));
+  ASSERT_TRUE(lsp_response_contains(signature, "split(delimiter)"));
+  ASSERT_FALSE(lsp_response_contains(signature, "split(text, delimiter)"));
+  free(signature);
+
+  char *hover = lsp_hover(g_ctx, 1, 20);
+  ASSERT_PTR_NOT_NULL(hover);
+  ASSERT_TRUE(lsp_is_valid_json(hover));
+  ASSERT_TRUE(lsp_response_contains(hover, "**method** split(...)"));
+  free(hover);
+}
+
 TEST(lsp_completion_includes_core_stdlib_0_6_functions) {
   const char *code = "set value to 1\n";
   ASSERT_TRUE(lsp_did_open(g_ctx, "file:///test.kr", code));

--- a/tests/unit/test_parser.c
+++ b/tests/unit/test_parser.c
@@ -563,6 +563,66 @@ TEST(parse_function_call) {
   token_array_free(tokens);
 }
 
+TEST(parse_method_chain_desugars_receiver_arguments) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens =
+      tokenize("set result to text.uppercase().trim().split(\" \")", &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  ParseError *parse_err = NULL;
+  AST *ast = parse(tokens, &parse_err);
+  ASSERT_PTR_NULL(parse_err);
+  ASSERT_PTR_NOT_NULL(ast);
+
+  ASTNode *split = ast->statements[0]->as.assign.value;
+  ASSERT_INT_EQ(split->type, AST_CALL);
+  ASSERT_STR_EQ(split->as.call.name, "split");
+  ASSERT_INT_EQ(split->as.call.arg_count, 2);
+  ASSERT_INT_EQ(split->as.call.args[1]->type, AST_STRING);
+
+  ASTNode *trim = split->as.call.args[0];
+  ASSERT_INT_EQ(trim->type, AST_CALL);
+  ASSERT_STR_EQ(trim->as.call.name, "trim");
+  ASSERT_INT_EQ(trim->as.call.arg_count, 1);
+
+  ASTNode *uppercase = trim->as.call.args[0];
+  ASSERT_INT_EQ(uppercase->type, AST_CALL);
+  ASSERT_STR_EQ(uppercase->as.call.name, "uppercase");
+  ASSERT_INT_EQ(uppercase->as.call.arg_count, 1);
+  ASSERT_INT_EQ(uppercase->as.call.args[0]->type, AST_VAR);
+  ASSERT_STR_EQ(uppercase->as.call.args[0]->as.var_name, "text");
+
+  ast_free(ast);
+  token_array_free(tokens);
+}
+
+TEST(parse_qualified_call_with_separate_dots) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens = tokenize("call math.sqrt with 16", &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  AST *ast = parse(tokens, NULL);
+  ASSERT_PTR_NOT_NULL(ast);
+  ASSERT_STR_EQ(ast->statements[0]->as.call.name, "math.sqrt");
+  ast_free(ast);
+  token_array_free(tokens);
+}
+
+TEST(parse_method_chain_reports_missing_parenthesis) {
+  TokenizeError *tok_err = NULL;
+  TokenArray *tokens = tokenize("set result to text.trim", &tok_err);
+  ASSERT_PTR_NULL(tok_err);
+  ParseError *parse_err = NULL;
+  AST *ast = parse(tokens, &parse_err);
+  ASSERT_PTR_NOT_NULL(ast);
+  ASSERT_INT_EQ(ast->count, 0);
+  ASSERT_PTR_NOT_NULL(parse_err);
+  ASSERT_TRUE(strstr(parse_err->message, "LPAREN") != NULL);
+  ast_free(ast);
+  parse_error_free(parse_err);
+  token_array_free(tokens);
+}
+
 TEST(parse_return_statement) {
   TokenizeError *tok_err = NULL;
   TokenArray *tokens = tokenize("return 42", &tok_err);

--- a/tests/unit/test_tokenizer.c
+++ b/tests/unit/test_tokenizer.c
@@ -83,6 +83,29 @@ TEST(tokenize_float_number) {
   token_array_free(tokens);
 }
 
+TEST(tokenize_method_chain_dots_separately) {
+  TokenizeError *err = NULL;
+  TokenArray *tokens = tokenize("text.uppercase().trim()", &err);
+  ASSERT_PTR_NULL(err);
+  ASSERT_PTR_NOT_NULL(tokens);
+
+  size_t i = 0;
+  while (i < tokens->count && tokens->tokens[i].type == TOK_INDENT) {
+    i++;
+  }
+  ASSERT_INT_EQ(tokens->tokens[i + 0].type, TOK_NAME);
+  ASSERT_STR_EQ(tokens->tokens[i + 0].text, "text");
+  ASSERT_INT_EQ(tokens->tokens[i + 1].type, TOK_DOT);
+  ASSERT_INT_EQ(tokens->tokens[i + 2].type, TOK_NAME);
+  ASSERT_STR_EQ(tokens->tokens[i + 2].text, "uppercase");
+  ASSERT_INT_EQ(tokens->tokens[i + 3].type, TOK_LPAREN);
+  ASSERT_INT_EQ(tokens->tokens[i + 4].type, TOK_RPAREN);
+  ASSERT_INT_EQ(tokens->tokens[i + 5].type, TOK_DOT);
+  ASSERT_INT_EQ(tokens->tokens[i + 6].type, TOK_NAME);
+
+  token_array_free(tokens);
+}
+
 /**
  * @brief Test tokenization of negative integer literals
  *

--- a/tests/unit/test_vm.c
+++ b/tests/unit/test_vm.c
@@ -302,6 +302,77 @@ TEST(vm_builtin_map_basic) {
   vm_free(vm);
 }
 
+TEST(vm_method_chaining_string_and_collection_results) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+
+  Bytecode *bytecode = compile_string(
+      "set text to \"  alpha beta gamma  \"\n"
+      "set words to text.uppercase().trim().split(\" \")\n"
+      "set processed to [1, 2, 3, 4]"
+      ".filter(function with x: return x is greater than 2)"
+      ".map(function with x: return x times 10)\n"
+      "set multiline to text\n"
+      "    .trim()\n"
+      "    .uppercase()");
+  ASSERT_PTR_NOT_NULL(bytecode);
+  ASSERT_INT_EQ(vm_execute(vm, bytecode), 0);
+
+  KronosValue *words = vm_get_global(vm, "words");
+  ASSERT_PTR_NOT_NULL(words);
+  ASSERT_INT_EQ(words->type, VAL_LIST);
+  ASSERT_EQ(words->as.list.count, 3);
+  ASSERT_TRUE(strcmp(words->as.list.items[0]->as.string.data, "ALPHA") == 0);
+  ASSERT_TRUE(strcmp(words->as.list.items[2]->as.string.data, "GAMMA") == 0);
+
+  KronosValue *processed = vm_get_global(vm, "processed");
+  ASSERT_PTR_NOT_NULL(processed);
+  ASSERT_INT_EQ(processed->type, VAL_LIST);
+  ASSERT_EQ(processed->as.list.count, 2);
+  ASSERT_DOUBLE_EQ(processed->as.list.items[0]->as.number, 30.0);
+  ASSERT_DOUBLE_EQ(processed->as.list.items[1]->as.number, 40.0);
+
+  KronosValue *multiline = vm_get_global(vm, "multiline");
+  ASSERT_PTR_NOT_NULL(multiline);
+  ASSERT_TRUE(strcmp(multiline->as.string.data, "ALPHA BETA GAMMA") == 0);
+
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_method_chaining_unbracketed_list_literal) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+  Bytecode *bytecode = compile_string(
+      "set processed to list 1, 2, 3, 4"
+      ".filter(function with x: return x is greater than 2)"
+      ".map(function with x: return x times 2)");
+  ASSERT_PTR_NOT_NULL(bytecode);
+  ASSERT_INT_EQ(vm_execute(vm, bytecode), 0);
+  KronosValue *processed = vm_get_global(vm, "processed");
+  ASSERT_PTR_NOT_NULL(processed);
+  ASSERT_INT_EQ(processed->type, VAL_LIST);
+  ASSERT_EQ(processed->as.list.count, 2);
+  ASSERT_DOUBLE_EQ(processed->as.list.items[0]->as.number, 6.0);
+  ASSERT_DOUBLE_EQ(processed->as.list.items[1]->as.number, 8.0);
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
+TEST(vm_method_call_preserves_builtin_type_errors) {
+  KronosVM *vm = vm_new();
+  ASSERT_PTR_NOT_NULL(vm);
+  Bytecode *bytecode = compile_string(
+      "set bad to \"not a list\".map(function with x: return x)");
+  ASSERT_PTR_NOT_NULL(bytecode);
+  ASSERT_NE(vm_execute(vm, bytecode), 0);
+  ASSERT_PTR_NOT_NULL(vm->last_error_message);
+  ASSERT_TRUE(strstr(vm->last_error_message,
+                     "Function 'map' requires a list argument") != NULL);
+  bytecode_free(bytecode);
+  vm_free(vm);
+}
+
 TEST(vm_execute_list_comprehension_range) {
   KronosVM *vm = vm_new();
   ASSERT_PTR_NOT_NULL(vm);

--- a/website/content/docs/language/functions.mdx
+++ b/website/content/docs/language/functions.mdx
@@ -32,6 +32,38 @@ set greeting to call greet with "Alice"
 print greeting  # Prints: Hello, Alice!
 ```
 
+## Method Chaining
+
+Use postfix method syntax when the value on the left should be the first
+argument to a function. These two expressions are equivalent:
+
+```kronos
+set upper to text.uppercase()
+set upper to call uppercase with text
+```
+
+Additional arguments go inside parentheses, and each returned value can feed
+the next call:
+
+```kronos
+set words to text.uppercase().trim().split(" ")
+
+set processed to numbers
+    .filter(function with x: return x is greater than 2)
+    .map(function with x: return x times 2)
+```
+
+Chains work with variables, literals, parenthesized expressions, bracketed list
+literals, and the unbracketed `list` form:
+
+```kronos
+set title to ("  kronos  ").trim().capitalize()
+set doubled to list 1, 2, 3.filter(function with x: return x is greater than 1).map(function with x: return x times 2)
+```
+
+Method calls retain the called function's argument-count and type validation.
+Use the traditional `call name with ...` syntax for named arguments.
+
 ## Default Parameter Values
 
 Functions can have parameters with default values. Parameters with defaults are optional when calling the function:
@@ -363,4 +395,3 @@ function get_grade with score:
 
 print call get_grade with 85  # Prints: B
 ```
-

--- a/website/content/docs/quick-reference.mdx
+++ b/website/content/docs/quick-reference.mdx
@@ -167,6 +167,16 @@ call sort with numbers          # Sort list
 call to_number with "42"        # Parse number
 ```
 
+## Method Chaining
+
+```kronos
+set words to text.uppercase().trim().split(" ")
+set sorted to numbers.filter(function with x: return x is greater than 0).sort()
+```
+
+The receiver becomes the function's first argument; explicit arguments belong
+inside `(...)`. A chain may continue on an indented following line.
+
 ## Running Programs
 
 ```bash

--- a/website/content/docs/roadmap.mdx
+++ b/website/content/docs/roadmap.mdx
@@ -465,7 +465,7 @@ Stabilize the modules required for 1.0 language adoption.
 </Accordion>
 
 <Accordion title="Method Chaining (Beta)">
-Parser/runtime hardening for fluent APIs.
+✅ Completed — fluent calls are supported across the parser, runtime, and LSP.
 
 ```kronos
 set result to text.uppercase().trim().split(" ")


### PR DESCRIPTION
## Summary

Add method chaining across the Kronos frontend, runtime, LSP, tests, and documentation for the v0.6.0 release.

## Changes

- Add postfix method-call syntax such as `text.uppercase().trim().split(" ")`
- Pass the receiver as the called function’s first argument
- Support chained calls on variables, literals, parenthesized expressions, and list literals
- Support indented multiline chains
- Preserve qualified calls such as `math.sqrt` and `regex.match`
- Add LSP diagnostics, completion, hover, and signature help for method calls
- Retain built-in argument-count and receiver-type validation
- Refresh the self-hosting analysis
- Bump the reported version to `0.6.0`

## Testing

- Add tokenizer, parser, VM, and LSP tests
- Add passing end-to-end coverage for string and collection chains
- Add failure coverage for invalid receiver types

- [x] All existing tests pass
- [x] New tests added (if applicable)
- [x] Examples updated (if applicable)
- [x] Memory leak checks pass (if applicable)

## Documentation

- Mark method chaining complete in the v0.6.0 roadmap
- Document method syntax, multiline chains, arguments, and validation
- Update the website quick reference
- Refresh the bootstrap/self-hosting analysis

- [x] Examples updated (if applicable)
- [x] README/docs updated (if applicable)

## Breaking Changes

None